### PR TITLE
feat: export `loadConfig` function to tool developers that want to konw if user has specififed it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ async function lintStaged(
   }
 }
 
-module.exports = lintStaged
-
 lintStaged.loadConfig = loadConfig
 lintStaged.runAll = runAll
+
+module.exports = lintStaged

--- a/src/index.js
+++ b/src/index.js
@@ -19,20 +19,88 @@ function resolveConfig(configPath) {
   }
 }
 
-function loadConfig(configPath) {
-  const explorer = cosmiconfig('lint-staged', {
-    searchPlaces: [
-      'package.json',
-      '.lintstagedrc',
-      '.lintstagedrc.json',
-      '.lintstagedrc.yaml',
-      '.lintstagedrc.yml',
-      '.lintstagedrc.js',
-      'lint-staged.config.js'
-    ]
-  })
+/**
+ Load configuration for lint-staged. It is used internally but also can be used
+ by the user through the programming way.
 
-  return configPath ? explorer.load(resolveConfig(configPath)) : explorer.search()
+ Example usage:
+ * for the development tool providers, they want to figure out whether if the
+   user has configured `lint-staged` if or not, use the configured one directly
+   or the default configuration provided by the development tool provider
+ *
+ * @param {object} options
+ * @param {string} [options.configPath] the path which user specify to find out
+ * `lint-staged` configuration file
+ * @param {boolean} [options.debug] debug mode
+ * @param {Logger} [options.inputConfig] the configuration object provided by
+   user directly
+ * @param {Logger} [options.logger]
+ *
+ *
+ * @example
+ *
+ * const { loadConfig } = require('lint-staged')
+ *
+ * loadConfig({ configPath: '/some/path/contains/conf' })
+ *  .then((lintStagedConfig) => {
+ *    if (!lintStagedConfig) {
+ *      lintStagedConfig = require('./default-config')
+ *    }
+ *  })
+ */
+async function loadConfig({ logger = console, inputConfig, configPath, debug } = {}) {
+  debugLog('Loading config using `cosmiconfig`')
+
+  let result
+
+  if (inputConfig) {
+    result = { config: inputConfig, filepath: '(input)' }
+  } else {
+    const explorer = cosmiconfig('lint-staged', {
+      searchPlaces: [
+        'package.json',
+        '.lintstagedrc',
+        '.lintstagedrc.json',
+        '.lintstagedrc.yaml',
+        '.lintstagedrc.yml',
+        '.lintstagedrc.js',
+        'lint-staged.config.js'
+      ]
+    })
+
+    try {
+      result = await (configPath ? explorer.load(resolveConfig(configPath)) : explorer.search())
+    } catch (error) {
+      // It was probably a parsing error
+      logger.error(dedent`
+      Could not parse lint-staged config.
+
+      ${error}
+    `)
+      throw error
+    }
+  }
+
+  if (result == null) {
+    logger.error(`${errConfigNotFound.message}.`)
+    throw errConfigNotFound
+  }
+
+  debugLog('Successfully loaded config from `%s`:\n%O', result.filepath, result.config)
+  // result.config is the parsed configuration object
+  // result.filepath is the path to the config file that was found
+  const config = validateConfig(result.config, debug)
+  if (debug) {
+    // Log using logger to be able to test through `consolemock`.
+    logger.log('Running lint-staged with the following config:')
+    logger.log(stringifyObject(config, { indent: '  ' }))
+  } else {
+    // We might not be in debug mode but `DEBUG=lint-staged*` could have
+    // been set.
+    debugLog('ling-staged config:\n%O', config)
+  }
+
+  return { config, configFilePath: result.filepath }
 }
 
 /**
@@ -52,58 +120,31 @@ function loadConfig(configPath) {
  *
  * @returns {Promise<boolean>} Promise of whether the linting passed or failed
  */
-module.exports = function lintStaged(
+async function lintStaged(
   { configPath, config, relative = false, shell = false, quiet = false, debug = false } = {},
   logger = console
 ) {
-  debugLog('Loading config using `cosmiconfig`')
+  try {
+    config = (await loadConfig({ logger, configPath, inputConfig: config, debug })).config
+  } catch (error) {
+    logger.error() // empty line
+    // Print helpful message for all errors
+    logger.error(dedent`
+      Please make sure you have created it correctly.
+      See https://github.com/okonet/lint-staged#configuration.
+    `)
+    throw error
+  }
 
-  return (config ? Promise.resolve({ config, filepath: '(input)' }) : loadConfig(configPath))
-    .then(result => {
-      if (result == null) throw errConfigNotFound
-
-      debugLog('Successfully loaded config from `%s`:\n%O', result.filepath, result.config)
-      // result.config is the parsed configuration object
-      // result.filepath is the path to the config file that was found
-      const config = validateConfig(result.config)
-      if (debug) {
-        // Log using logger to be able to test through `consolemock`.
-        logger.log('Running lint-staged with the following config:')
-        logger.log(stringifyObject(config, { indent: '  ' }))
-      } else {
-        // We might not be in debug mode but `DEBUG=lint-staged*` could have
-        // been set.
-        debugLog('lint-staged config:\n%O', config)
-      }
-
-      return runAll({ config, relative, shell, quiet, debug }, logger)
-        .then(() => {
-          debugLog('tasks were executed successfully!')
-          return Promise.resolve(true)
-        })
-        .catch(error => {
-          printErrors(error, logger)
-          return Promise.resolve(false)
-        })
-    })
-    .catch(err => {
-      if (err === errConfigNotFound) {
-        logger.error(`${err.message}.`)
-      } else {
-        // It was probably a parsing error
-        logger.error(dedent`
-          Could not parse lint-staged config.
-
-          ${err}
-        `)
-      }
-      logger.error() // empty line
-      // Print helpful message for all errors
-      logger.error(dedent`
-        Please make sure you have created it correctly.
-        See https://github.com/okonet/lint-staged#configuration.
-      `)
-
-      return Promise.reject(err)
-    })
+  try {
+    await runAll({ config, relative, shell, quiet, debug }, logger)
+    debug('linters were executed successfully!')
+    return true
+  } catch (error) {
+    // Errors detected, printing and exiting with non-zero
+    printErrors(error, logger)
+    return false
+  }
 }
+
+module.exports = { runAll, lintStaged, loadConfig }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,7 +7,7 @@ jest.unmock('execa')
 // eslint-disable-next-line import/first
 import getStagedFiles from '../src/getStagedFiles'
 // eslint-disable-next-line import/first
-import lintStaged from '../src/index'
+import { lintStaged } from '../src/index'
 
 jest.mock('../src/getStagedFiles')
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,7 +7,7 @@ jest.unmock('execa')
 // eslint-disable-next-line import/first
 import getStagedFiles from '../src/getStagedFiles'
 // eslint-disable-next-line import/first
-import { lintStaged } from '../src/index'
+import lintStaged from '../src/index'
 
 jest.mock('../src/getStagedFiles')
 


### PR DESCRIPTION
`lint-staged` is awesome, I'm ready to develop a tool that integrates with `lint-staged`.

I want to fall back to a default configuration file while the user did not write their own `lint-staged` configuration, so I need official ways to check if the user has specified it or not.

Babel has a similar function that do this:

https://github.com/babel/babel/blob/dca61251286716b49479678c7be513650617da77/packages/babel-core/src/config/partial.js#L81-L102

I hope that `lint-staged` can provide one like that, thanks 🙏