### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ module.exports = {
 ```js
 // .lintstagedrc.js
 module.exports = {
-  '**/*.js?(x)': filenames => (filenames.length > 10 ? 'eslint .' : `eslint ${filenames.join(' ')}`)
+  '**/*.js?(x)': filenames => (filenames.length > 10 ? 'eslint .' : `eslint ${filenames.map(filename => `'${filename}'`).join(' ')}`)
 }
 ```
 


### PR DESCRIPTION
Plain `filenames.join(' ')` will lead to errors if/when some file paths will have a space in it.

cc @zemlanin