### PR TITLE
fix: run task command on files deep copy

### DIFF
--- a/.changeset/sixty-stingrays-glow.md
+++ b/.changeset/sixty-stingrays-glow.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Previously it was possible for a function task to mutate the list of staged files passed to the function, and accidentally affect the generation of other tasks. This is now fixed by passing a copy of the original file list instead.

--- a/lib/makeCmdTasks.js
+++ b/lib/makeCmdTasks.js
@@ -24,7 +24,9 @@ export const makeCmdTasks = async ({ commands, cwd, files, gitDir, shell, verbos
   for (const cmd of commandArray) {
     // command function may return array of commands that already include `stagedFiles`
     const isFn = typeof cmd === 'function'
-    const resolved = isFn ? await cmd(files) : cmd
+
+    /** Pass copy of file list to prevent mutation by function from config file. */
+    const resolved = isFn ? await cmd([...files]) : cmd
 
     const resolvedArray = Array.isArray(resolved) ? resolved : [resolved] // Wrap non-array command as array
 

--- a/test/unit/makeCmdTasks.spec.js
+++ b/test/unit/makeCmdTasks.spec.js
@@ -124,4 +124,25 @@ describe('makeCmdTasks', () => {
               Function task should return a string or an array of strings"
           `)
   })
+
+  it('should prevent function from mutating original file list', async () => {
+    const files = ['test.js']
+
+    const res = await makeCmdTasks({
+      commands: (stagedFiles) => {
+        /** Array.splice() mutates the array */
+        stagedFiles.splice(0, 1)
+        expect(stagedFiles).toEqual([])
+        return stagedFiles.map((file) => `test ${file}`)
+      },
+      gitDir,
+      files,
+    })
+
+    /** Because function mutated file list, it was empty and no tasks were created... */
+    expect(res.length).toBe(0)
+
+    /** ...but the original file list was not mutated */
+    expect(files).toEqual(['test.js'])
+  })
 })


### PR DESCRIPTION
This prevents the task command to change the files array by inadvertence. It happened to me and I took a long moment to diagnose the issue.

```
Task in generateTasks
{
  pattern: 'apps/dummy/dummy/**/*.js',
  commands: [Function: apps/dummy/dummy/**/*.js],
  fileList: [
    '/Users/lounesksouri/dummy/apps/dummy/dummy/src/config.js'
  ]
}
Task in runAll after makeCmdTasks
{
  pattern: 'apps/dummy/dummy/**/*.js',
  commands: [Function: apps/dummy/dummy/**/*.js],
  fileList: []
}
```