### PR TITLE
feat: support symbolic link git dir

### DIFF
--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -19,6 +19,11 @@ const resolveGitConfigDir = async (gitDir) => {
   const stats = await fs.lstat(defaultDir)
   // If .git is a directory, use it
   if (stats.isDirectory()) return defaultDir
+  // If .git is a symbolic link, find realpath and use it,
+  // thought realpath is a directory, avoid infinite recursion.
+  if (stats.isSymbolicLink()) {
+    return fs.realpath(defaultDir);
+  }
   // Otherwise .git is a file containing path to real location
   const file = (await readFile(defaultDir)).toString()
   return path.resolve(gitDir, file.replace(/^gitdir: /, '')).trim()


### PR DESCRIPTION
Related: #1351 

## Changes
+ when git dir is symbolic link, use `fs.realpath` find once as result