### PR TITLE
fix: when determining git directory, use `fs.realpath()` only for sym…

### DIFF
--- a/.changeset/sharp-apes-attend.md
+++ b/.changeset/sharp-apes-attend.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+When determining git directory, use `fs.realpath()` only for symlinks. It looks like `fs.realpath()` changes some Windows mapped network filepaths unexpectedly, causing issues.

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -15,10 +15,19 @@ const debugLog = debug('lint-staged:resolveGitRepo')
  */
 const resolveGitConfigDir = async (gitDir) => {
   // Get the real path in case it's a symlink
-  const defaultDir = await fs.realpath(path.join(gitDir, '.git'))
+  const defaultDir = path.join(gitDir, '.git')
   const stats = await fs.lstat(defaultDir)
+
   // If .git is a directory, use it
-  if (stats.isDirectory()) return defaultDir
+  if (stats.isDirectory()) {
+    return defaultDir
+  }
+
+  // If .git is a symlink, return the real location
+  if (stats.isSymbolicLink()) {
+    return await fs.realpath(gitDir)
+  }
+
   // Otherwise .git is a file containing path to real location
   const file = (await readFile(defaultDir)).toString()
   return path.resolve(gitDir, file.replace(/^gitdir: /, '')).trim()


### PR DESCRIPTION
…links