### PR TITLE
fix: restore .pre-commit-hooks.yaml

### DIFF
--- a/.changeset/quick-taxis-teach.md
+++ b/.changeset/quick-taxis-teach.md
@@ -2,4 +2,4 @@
 'lint-staged': patch
 ---
 
-restore yaml for pre-commit
+Restore config file for `pre-commit`

--- a/.changeset/quick-taxis-teach.md
+++ b/.changeset/quick-taxis-teach.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+restore yaml for pre-commit

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: lint-staged
+  name: lint-staged
+  entry: lint-staged
+  language: node
+


### PR DESCRIPTION
This file is essential when using [pre-commit](https://pre-commit.com/). It throws an error if this file is missing.
```
$ pre-commit run       
An error has occurred: InvalidManifestError: 
=====> /Users/username/.cache/pre-commit/reponfms5uhx/.pre-commit-hooks.yaml is not a file
```