### PR TITLE
fix: ignore stdin of spawned commands

### DIFF
--- a/.changeset/dirty-eagles-decide.md
+++ b/.changeset/dirty-eagles-decide.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Ignore stdin of spawned commands so that they don't get stuck waiting. Until now, _lint-staged_ has used the default settings to spawn linter commands. This means the `stdin` of the spawned commands has accepted input, and essentially gotten stuck waiting. Now the `stdin` is ignored and commands will no longer get stuck. If you relied on this behavior, please open a new issue and describe how; the behavior has not been intended.

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-node_modules
         with:
           path: node_modules

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 20
       # Install node_modules
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-node_modules
         with:
           path: node_modules
@@ -52,7 +52,7 @@ jobs:
         with:
           node-version: 20
       # Install node_modules
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-node_modules
         with:
           path: node_modules
@@ -72,7 +72,7 @@ jobs:
         with:
           node-version: 20
       # Install node_modules
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-node_modules
         with:
           path: node_modules
@@ -106,7 +106,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       # Install node_modules
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-node_modules
         with:
           path: node_modules
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: cache-node_modules
         with:
           path: node_modules

--- a/lib/execGit.js
+++ b/lib/execGit.js
@@ -19,6 +19,7 @@ export const execGit = async (cmd, options = {}) => {
       ...options,
       all: true,
       cwd: options.cwd || process.cwd(),
+      stdin: 'ignore',
     })
     return stdout
   } catch ({ all }) {

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -152,6 +152,7 @@ export const resolveTaskFn = ({
     preferLocal: true,
     reject: false,
     shell,
+    stdin: 'ignore',
   }
 
   debugLog('execaOptions:', execaOptions)

--- a/test/unit/execGit.spec.js
+++ b/test/unit/execGit.spec.js
@@ -21,6 +21,7 @@ describe('execGit', () => {
     expect(execa).toHaveBeenCalledWith('git', [...GIT_GLOBAL_OPTIONS, 'init', 'param'], {
       all: true,
       cwd,
+      stdin: 'ignore',
     })
   })
 
@@ -30,6 +31,7 @@ describe('execGit', () => {
     expect(execa).toHaveBeenCalledWith('git', [...GIT_GLOBAL_OPTIONS, 'init', 'param'], {
       all: true,
       cwd,
+      stdin: 'ignore',
     })
   })
 })

--- a/test/unit/makeCmdTasks.spec.js
+++ b/test/unit/makeCmdTasks.spec.js
@@ -49,6 +49,7 @@ describe('makeCmdTasks', () => {
       preferLocal: true,
       reject: false,
       shell: false,
+      stdin: 'ignore',
     })
     taskPromise = linter2.task()
     expect(taskPromise).toBeInstanceOf(Promise)
@@ -59,6 +60,7 @@ describe('makeCmdTasks', () => {
       preferLocal: true,
       reject: false,
       shell: false,
+      stdin: 'ignore',
     })
   })
 

--- a/test/unit/resolveTaskFn.spec.js
+++ b/test/unit/resolveTaskFn.spec.js
@@ -40,6 +40,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: false,
+      stdin: 'ignore',
     })
   })
 
@@ -58,6 +59,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: false,
+      stdin: 'ignore',
     })
   })
 
@@ -77,6 +79,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: true,
+      stdin: 'ignore',
     })
   })
 
@@ -95,6 +98,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: true,
+      stdin: 'ignore',
     })
   })
 
@@ -113,6 +117,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: '/bin/bash',
+      stdin: 'ignore',
     })
   })
 
@@ -131,6 +136,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: false,
+      stdin: 'ignore',
     })
   })
 
@@ -145,6 +151,7 @@ describe('resolveTaskFn', () => {
       preferLocal: true,
       reject: false,
       shell: false,
+      stdin: 'ignore',
     })
   })
 

--- a/test/unit/resolveTaskFn.unmocked.spec.js
+++ b/test/unit/resolveTaskFn.unmocked.spec.js
@@ -17,7 +17,7 @@ describe('resolveTaskFn', () => {
     const context = getInitialState()
 
     const taskFn = resolveTaskFn({
-      command: 'node',
+      command: 'node -e "setTimeout(() => void 0, 10000)"',
       isFn: true,
     })
     const taskPromise = taskFn(context)
@@ -31,6 +31,8 @@ describe('resolveTaskFn', () => {
     await expect(task2Promise).rejects.toThrowErrorMatchingInlineSnapshot(
       `"node -e "process.exit(1)" [FAILED]"`
     )
-    await expect(taskPromise).rejects.toThrowErrorMatchingInlineSnapshot(`"node [KILLED]"`)
+    await expect(taskPromise).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"node -e "setTimeout(() => void 0, 10000)" [KILLED]"`
+    )
   })
 })


### PR DESCRIPTION
This should fix https://github.com/lint-staged/lint-staged/issues/1293 and https://github.com/lint-staged/lint-staged/issues/1019