### PR TITLE
Fix #1421 - log and rethrow errors from config validation

### DIFF
--- a/.changeset/beige-nails-agree.md
+++ b/.changeset/beige-nails-agree.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Bugfix to prevent silent failure when configuration validation throws an error

--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -94,8 +94,18 @@ export const searchConfigs = async (
           if (configPath !== filepath) {
             debugLog('Config file "%s" resolved to "%s"', configPath, filepath)
           }
-
-          configs[configPath] = validateConfig(config, filepath, logger)
+          try {
+            configs[configPath] = validateConfig(config, filepath, logger)
+          } catch (error) {
+            // Log and rethrow so user can see the reason for failed config load
+            debugLog(error)
+            logger.error(
+              'Error while loading and validating configuration `%s`:\n\t%s',
+              configPath,
+              error.message
+            )
+            throw error
+          }
         }
       })
     )


### PR DESCRIPTION
Fixes a silent failure to load configurations described in #1421 

I was unsure where exactly to catch the error, since it doesn't seem like there is a central place where unexpected errors are caught and logged, before exiting the program.

If this is the case, would it be a good idea to wrap part of the main function to better include logging for other unexpected errors?