### PR TITLE
fix: improve error logging when failing to parse config file

### DIFF
--- a/.changeset/smart-pets-melt.md
+++ b/.changeset/smart-pets-melt.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Improve error logging when failing to read or parse a configuration file

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -7,6 +7,7 @@ import debug from 'debug'
 import YAML from 'yaml'
 
 import { dynamicImport } from './dynamicImport.js'
+import { failedToLoadConfig } from './messages.js'
 import { resolveConfig } from './resolveConfig.js'
 import {
   CONFIG_FILE_NAMES,
@@ -117,8 +118,8 @@ export const loadConfig = async ({ configPath, cwd }, logger) => {
 
     return { config, filepath }
   } catch (error) {
-    debugLog('Failed to load configuration!')
-    logger.error(error)
+    debugLog('Failed to load configuration from `%s` with error:\n', configPath, error)
+    logger.error(failedToLoadConfig(configPath))
     return {}
   }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -85,3 +85,15 @@ export const RESTORE_STASH_EXAMPLE = `  Any lost modifications can be restored f
 `
 
 export const CONFIG_STDIN_ERROR = chalk.redBright(`${error} Failed to read config from stdin.`)
+
+export const failedToLoadConfig = (filepath) =>
+  chalk.redBright(`${error} Failed to read config from file "${filepath}".`)
+
+export const failedToParseConfig = (
+  filepath,
+  error
+) => `${chalk.redBright(`${error} Failed to parse config from file "${filepath}".`)}
+
+${error}
+
+See https://github.com/okonet/lint-staged#configuration.`

--- a/lib/validateConfig.js
+++ b/lib/validateConfig.js
@@ -4,7 +4,7 @@ import { inspect } from 'node:util'
 
 import debug from 'debug'
 
-import { configurationError } from './messages.js'
+import { configurationError, failedToParseConfig } from './messages.js'
 import { ConfigEmptyError, ConfigFormatError } from './symbols.js'
 import { validateBraces } from './validateBraces.js'
 
@@ -23,14 +23,7 @@ const TEST_DEPRECATED_KEYS = new Map([
   ['relative', (key) => typeof key === 'boolean'],
 ])
 
-/**
- * Runs config validation. Throws error if the config is not valid.
- * @param {Object} config
- * @param {string} configPath
- * @param {Logger} logger
- * @returns {Object} config
- */
-export const validateConfig = (config, configPath, logger) => {
+export const validateConfigLogic = (config, configPath, logger) => {
   debugLog('Validating config from `%s`...', configPath)
 
   if (!config || (typeof config !== 'object' && typeof config !== 'function')) {
@@ -100,11 +93,7 @@ export const validateConfig = (config, configPath, logger) => {
   if (errors.length) {
     const message = errors.join('\n\n')
 
-    logger.error(`Could not parse lint-staged config.
-
-${message}
-
-See https://github.com/okonet/lint-staged#configuration.`)
+    logger.error(failedToParseConfig(configPath, message))
 
     throw new Error(message)
   }
@@ -113,4 +102,20 @@ See https://github.com/okonet/lint-staged#configuration.`)
   debugLog(inspect(config, { compact: false }))
 
   return validatedConfig
+}
+
+/**
+ * Runs config validation. Throws error if the config is not valid.
+ * @param {Object} config
+ * @param {string} configPath
+ * @param {Logger} logger
+ * @returns {Object} config
+ */
+export const validateConfig = (config, configPath, logger) => {
+  try {
+    return validateConfigLogic(config, configPath, logger)
+  } catch (error) {
+    logger.error(failedToParseConfig(configPath, error))
+    throw error
+  }
 }

--- a/test/unit/__snapshots__/validateConfig.spec.js.snap
+++ b/test/unit/__snapshots__/validateConfig.spec.js.snap
@@ -64,9 +64,152 @@ exports[`validateConfig should throw when detecting deprecated advanced configur
 
 exports[`validateConfig should throw when detecting deprecated advanced configuration 2`] = `
 "
-ERROR Could not parse lint-staged config.
+ERROR ✖ Validation Error:
+
+  Invalid value for 'chunkSize': 10
+
+  Advanced configuration has been deprecated.
 
 ✖ Validation Error:
+
+  Invalid value for 'concurrent': false
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'globOptions': { matchBase: false }
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'ignore': [ 'test.js' ]
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'linters': { '*.js': [ 'eslint' ] }
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'relative': true
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'renderer': 'silent'
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'subTaskConcurrency': 10
+
+  Advanced configuration has been deprecated. Failed to parse config from file ".lintstagedrc.json".
+
+✖ Validation Error:
+
+  Invalid value for 'chunkSize': 10
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'concurrent': false
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'globOptions': { matchBase: false }
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'ignore': [ 'test.js' ]
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'linters': { '*.js': [ 'eslint' ] }
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'relative': true
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'renderer': 'silent'
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'subTaskConcurrency': 10
+
+  Advanced configuration has been deprecated.
+
+See https://github.com/okonet/lint-staged#configuration.
+ERROR Error: ✖ Validation Error:
+
+  Invalid value for 'chunkSize': 10
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'concurrent': false
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'globOptions': { matchBase: false }
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'ignore': [ 'test.js' ]
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'linters': { '*.js': [ 'eslint' ] }
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'relative': true
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'renderer': 'silent'
+
+  Advanced configuration has been deprecated.
+
+✖ Validation Error:
+
+  Invalid value for 'subTaskConcurrency': 10
+
+  Advanced configuration has been deprecated. Failed to parse config from file ".lintstagedrc.json".
+
+Error: ✖ Validation Error:
 
   Invalid value for 'chunkSize': 10
 

--- a/test/unit/loadConfig.spec.js
+++ b/test/unit/loadConfig.spec.js
@@ -48,12 +48,14 @@ describe('loadConfig', () => {
   })
 
   it('should not return config when YAML config file is invalid', async () => {
-    expect.assertions(1)
+    expect.assertions(2)
 
     const { config } = await loadConfig(
       { configPath: path.join(__dirname, '__mocks__', 'invalid-config-file.yml') },
       logger
     )
+
+    expect(logger.printHistory()).toMatch('Failed to read config from file')
 
     expect(config).toBeUndefined()
   })


### PR DESCRIPTION
Fixes https://github.com/lint-staged/lint-staged/issues/1421 by adding more generic error logging when `validateConfig` function throws for unknown reasons.