### PR TITLE
Dependency version ranges

### DIFF
--- a/.changeset/lovely-balloons-doubt.md
+++ b/.changeset/lovely-balloons-doubt.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Allow approximately equivalent versions of direct dependencies by using the "~" character in the version ranges. This means a more recent patch version of a dependency is allowed if available.

--- a/.changeset/tender-frogs-do.md
+++ b/.changeset/tender-frogs-do.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': minor
+---
+
+Upgrade micromatch@4.0.7

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "execa": "8.0.1",
         "lilconfig": "3.1.1",
         "listr2": "8.2.1",
-        "micromatch": "4.0.6",
+        "micromatch": "4.0.7",
         "pidtree": "0.6.0",
         "string-argv": "0.3.2",
         "yaml": "2.4.2"
@@ -7720,26 +7720,16 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.6.tgz",
-      "integrity": "sha512-Y4Ypn3oujJYxJcMacVgcs92wofTHxp9FzfDpQON4msDefoC0lb3ETvQLOdLcbhSwU1bz8HrL/1sygfBIHudrkQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
-        "picomatch": "^4.0.2"
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mimic-fn": {
@@ -8218,7 +8208,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "15.2.4",
       "license": "MIT",
       "dependencies": {
-        "chalk": "5.3.0",
-        "commander": "12.1.0",
-        "debug": "4.3.4",
-        "execa": "8.0.1",
-        "lilconfig": "3.1.1",
-        "listr2": "8.2.1",
-        "micromatch": "4.0.7",
-        "pidtree": "0.6.0",
-        "string-argv": "0.3.2",
-        "yaml": "2.4.2"
+        "chalk": "~5.3.0",
+        "commander": "~12.1.0",
+        "debug": "~4.3.4",
+        "execa": "~8.0.1",
+        "lilconfig": "~3.1.1",
+        "listr2": "~8.2.1",
+        "micromatch": "~4.0.7",
+        "pidtree": "~0.6.0",
+        "string-argv": "~0.3.2",
+        "yaml": "~2.4.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "execa": "8.0.1",
     "lilconfig": "3.1.1",
     "listr2": "8.2.1",
-    "micromatch": "4.0.6",
+    "micromatch": "4.0.7",
     "pidtree": "0.6.0",
     "string-argv": "0.3.2",
     "yaml": "2.4.2"

--- a/package.json
+++ b/package.json
@@ -36,16 +36,16 @@
     "tag": "npx changeset tag"
   },
   "dependencies": {
-    "chalk": "5.3.0",
-    "commander": "12.1.0",
-    "debug": "4.3.4",
-    "execa": "8.0.1",
-    "lilconfig": "3.1.1",
-    "listr2": "8.2.1",
-    "micromatch": "4.0.7",
-    "pidtree": "0.6.0",
-    "string-argv": "0.3.2",
-    "yaml": "2.4.2"
+    "chalk": "~5.3.0",
+    "commander": "~12.1.0",
+    "debug": "~4.3.4",
+    "execa": "~8.0.1",
+    "lilconfig": "~3.1.1",
+    "listr2": "~8.2.1",
+    "micromatch": "~4.0.7",
+    "pidtree": "~0.6.0",
+    "string-argv": "~0.3.2",
+    "yaml": "~2.4.2"
   },
   "devDependencies": {
     "@changesets/changelog-github": "0.5.0",


### PR DESCRIPTION
This PR updates `micromatch` to  version 4.0.7 and adjusts all direct dependency version ranges to allow "_approximately equivalent versions_" by using the `~` character; this means a more recent patch version is allowed.