### PR TITLE
fix: use native git command to get top-level directory for repo

### DIFF
--- a/.changeset/stale-ants-hope.md
+++ b/.changeset/stale-ants-hope.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Use native "git rev-parse" commands to determine git repo root directory and the .git config directory, instead of using custom logic. This hopefully makes path resolution more robust on non-POSIX systems.

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -1,37 +1,9 @@
-import fs from 'node:fs/promises'
-import path from 'node:path'
-
 import debug from 'debug'
 
 import { execGit } from './execGit.js'
-import { readFile } from './file.js'
 import { normalizePath } from './normalizePath.js'
 
 const debugLog = debug('lint-staged:resolveGitRepo')
-
-/**
- * Resolve path to the .git directory, with special handling for
- * submodules and worktrees
- */
-const resolveGitConfigDir = async (gitDir) => {
-  // Get the real path in case it's a symlink
-  const defaultDir = path.join(gitDir, '.git')
-  const stats = await fs.lstat(defaultDir)
-
-  // If .git is a directory, use it
-  if (stats.isDirectory()) {
-    return defaultDir
-  }
-
-  // If .git is a symlink, return the real location
-  if (stats.isSymbolicLink()) {
-    return await fs.realpath(gitDir)
-  }
-
-  // Otherwise .git is a file containing path to real location
-  const file = (await readFile(defaultDir)).toString()
-  return path.resolve(gitDir, file.replace(/^gitdir: /, '')).trim()
-}
 
 /**
  * Resolve git directory and possible submodule paths
@@ -49,9 +21,11 @@ export const resolveGitRepo = async (cwd = process.cwd()) => {
     const gitDir = normalizePath(
       await execGit(['rev-parse', '--path-format=absolute', '--show-toplevel'], { cwd })
     )
-    const gitConfigDir = normalizePath(await resolveGitConfigDir(gitDir))
-
     debugLog('Resolved git directory to be `%s`', gitDir)
+
+    const gitConfigDir = normalizePath(
+      await execGit(['rev-parse', '--path-format=absolute', '--absolute-git-dir'], { cwd })
+    )
     debugLog('Resolved git config directory to be `%s`', gitConfigDir)
 
     return { gitDir, gitConfigDir }

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -33,22 +33,6 @@ const resolveGitConfigDir = async (gitDir) => {
   return path.resolve(gitDir, file.replace(/^gitdir: /, '')).trim()
 }
 
-// exported for test
-export const determineGitDir = (cwd, relativeDir) => {
-  // if relative dir and cwd have different endings normalize it
-  // this happens under windows, where normalize is unable to normalize git's output
-  if (relativeDir && relativeDir.endsWith(path.sep)) {
-    relativeDir = relativeDir.slice(0, -1)
-  }
-  if (relativeDir) {
-    // the current working dir is inside the git top-level directory
-    return cwd.substring(0, cwd.lastIndexOf(relativeDir))
-  } else {
-    // the current working dir is the top-level git directory
-    return cwd
-  }
-}
-
 /**
  * Resolve git directory and possible submodule paths
  */
@@ -62,10 +46,9 @@ export const resolveGitRepo = async (cwd = process.cwd()) => {
     debugLog('Unset GIT_WORK_TREE (was `%s`)', process.env.GIT_WORK_TREE)
     delete process.env.GIT_WORK_TREE
 
-    // read the path of the current directory relative to the top-level directory
-    // don't read the toplevel directly, it will lead to an posix conform path on non posix systems (cygwin)
-    const gitRel = normalizePath(await execGit(['rev-parse', '--show-prefix'], { cwd }))
-    const gitDir = normalizePath(determineGitDir(normalizePath(cwd), gitRel))
+    const gitDir = normalizePath(
+      await execGit(['rev-parse', '--path-format=absolute', '--show-toplevel'], { cwd })
+    )
     const gitConfigDir = normalizePath(await resolveGitConfigDir(gitDir))
 
     debugLog('Resolved git directory to be `%s`', gitDir)

--- a/test/unit/resolveGitRepo.spec.js
+++ b/test/unit/resolveGitRepo.spec.js
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { normalizePath } from '../../lib/normalizePath.js'
-import { determineGitDir, resolveGitRepo } from '../../lib/resolveGitRepo.js'
+import { resolveGitRepo } from '../../lib/resolveGitRepo.js'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
@@ -44,28 +44,5 @@ describe('resolveGitRepo', () => {
   it('should return null when not in a git directory', async () => {
     const { gitDir } = await resolveGitRepo({ cwd: '/' }) // assume root is not a git directory
     expect(gitDir).toEqual(null)
-  })
-
-  describe('determineGitDir', () => {
-    it('should resolve to current working dir when relative dir is empty', () => {
-      const cwd = process.cwd()
-      const relativeDir = undefined
-      const rootDir = determineGitDir(cwd, relativeDir)
-      expect(normalizePath(rootDir)).toEqual(normalizePath(cwd))
-    })
-
-    it('should resolve to parent dir when relative dir is child', () => {
-      const relativeDir = 'bar'
-      const cwd = process.cwd() + path.sep + 'bar'
-      const rootDir = determineGitDir(cwd, relativeDir)
-      expect(normalizePath(rootDir)).toEqual(normalizePath(process.cwd()))
-    })
-
-    it('should resolve to parent dir when relative dir is child and child has trailing dir separator', () => {
-      const relativeDir = 'bar' + path.sep
-      const cwd = process.cwd() + path.sep + 'bar'
-      const rootDir = determineGitDir(cwd, relativeDir)
-      expect(normalizePath(rootDir)).toEqual(normalizePath(process.cwd()))
-    })
   })
 })


### PR DESCRIPTION
Use native "git rev-parse" commands to determine git repo root directory and the .git config directory, instead of using custom logic. This hopefully makes path resolution more robust on non-POSIX systems.