### PR TITLE
fix: drop option to support earlier Git versions

### DIFF
--- a/.changeset/itchy-shrimps-shake.md
+++ b/.changeset/itchy-shrimps-shake.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+In the previous version the native `git rev-parse --show-toplevel` command was taken into use for resolving the current git repo root. This version drops the `--path-format=absolute` option to support earlier git versions since it's also the default behavior.

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -18,14 +18,10 @@ export const resolveGitRepo = async (cwd = process.cwd()) => {
     debugLog('Unset GIT_WORK_TREE (was `%s`)', process.env.GIT_WORK_TREE)
     delete process.env.GIT_WORK_TREE
 
-    const gitDir = normalizePath(
-      await execGit(['rev-parse', '--path-format=absolute', '--show-toplevel'], { cwd })
-    )
+    const gitDir = normalizePath(await execGit(['rev-parse', '--show-toplevel'], { cwd }))
     debugLog('Resolved git directory to be `%s`', gitDir)
 
-    const gitConfigDir = normalizePath(
-      await execGit(['rev-parse', '--path-format=absolute', '--absolute-git-dir'], { cwd })
-    )
+    const gitConfigDir = normalizePath(await execGit(['rev-parse', '--absolute-git-dir'], { cwd }))
     debugLog('Resolved git config directory to be `%s`', gitConfigDir)
 
     return { gitDir, gitConfigDir }


### PR DESCRIPTION
Fixes https://github.com/lint-staged/lint-staged/issues/1437