### PR TITLE
Update and edit Husky to v9.1.2 according to latest patchnotes

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
 npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
 node bin/lint-staged.js

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,1 @@
-#!/usr/bin/env sh
-
 npx --no changeset status

--- a/README.md
+++ b/README.md
@@ -485,8 +485,7 @@ All examples assume you've already set up lint-staged in the `package.json` file
 In `.husky/pre-commit`
 
 ```shell
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
+# .husky/pre-commit
 
 npx lint-staged
 ```
@@ -691,9 +690,6 @@ If updating Git doesn't help, you can try to manually redirect the output in you
 
 ```shell
 # .husky/pre-commit
-
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then exec >/dev/tty 2>&1; fi
 


### PR DESCRIPTION
In latest release of Husky ([v9.1.2](https://github.com/typicode/husky/releases/tag/v9.1.2)) it is stated:

> Show a message instead of automatically removing deprecated code.
>
> This only concerns projects that still have the following code in their hooks:
> ```diff
> - #!/usr/bin/env sh # <- This is deprecated, remove it
> - . "$(dirname -- "$0")/_/husky.sh"  # <- This is deprecated, remove it
> 
> # Rest of your hook code

So I both updated README and Husky hooks, tested them by this procedure:

1. Installed NPM packages;
2. Initialized Husky by `husky` command;
3. Tried to push empty commit with name `test: testing Husky hooks after update`

Git accepted commit, so I think it's a good sign, in my commits I provided source and link to the Husky's release patchnote to avoid confusion in future.