### PR TITLE
fix: set max event listeners to the number of tasks

### DIFF
--- a/.changeset/dull-pants-remain.md
+++ b/.changeset/dull-pants-remain.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Set the maximum number of event listeners to the number of tasks. This should silence the console warning `MaxListenersExceededWarning: Possible EventEmitter memory leak detected`.

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -161,6 +161,14 @@ export const runAll = async (
     ...getRenderer({ debug, quiet }, logger),
   }
 
+  /**
+   * This is used to set max event listener count to the total number
+   * of generated tasks. The event listener is used to keep track of
+   * the interrupt signal and kill all tasks when it happens. See the
+   * `interruptExecutionOnError` in `resolveTaskFn`.
+   */
+  let listrTaskCount = 0
+
   const listrTasks = []
 
   // Set of all staged files that matched a task glob. Values in a set are unique.
@@ -230,6 +238,8 @@ export const runAll = async (
           })
         )
       )
+
+      listrTaskCount += chunkListrTasks.length
 
       listrTasks.push({
         title:
@@ -320,6 +330,9 @@ export const runAll = async (
     ],
     listrOptions
   )
+
+  debugLog('Set max event listeners to the number of tasks: %i', listrTaskCount)
+  ctx.events.setMaxListeners(listrTaskCount)
 
   await runner.run()
 


### PR DESCRIPTION
Node.js has a default max listener limit of 10 and emits a warning when going over:

```
(node:3528) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 lint-staged:taskError listeners added to [EventEmitter]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```