### PR TITLE
fix: running eslint on filenames containing spaces

### DIFF
--- a/.changeset/chilled-rules-drive.md
+++ b/.changeset/chilled-rules-drive.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Escape paths containing spaces when using the "shell" option.

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -159,7 +159,12 @@ export const resolveTaskFn = ({
 
   return async (ctx = getInitialState()) => {
     const execaChildProcess = shell
-      ? execaCommand(isFn ? command : `${command} ${files.join(' ')}`, execaOptions)
+      ? execaCommand(
+          isFn
+            ? command
+            : `${command} ${files.map((file) => file.replaceAll(' ', '\\ ')).join(' ')}`,
+          execaOptions
+        )
       : execa(cmd, isFn ? args : args.concat(files), execaOptions)
 
     const quitInterruptCheck = interruptExecutionOnError(ctx, execaChildProcess)

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -8,6 +8,11 @@ import { error, info } from './figures.js'
 import { getInitialState } from './state.js'
 import { TaskError } from './symbols.js'
 
+/**
+ * @see https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/command.js#L32-L37
+ */
+const escapeSpaces = (input) => input.replaceAll(' ', '\\ ')
+
 const TASK_ERROR = 'lint-staged:taskError'
 
 const debugLog = debug('lint-staged:resolveTaskFn')
@@ -160,9 +165,7 @@ export const resolveTaskFn = ({
   return async (ctx = getInitialState()) => {
     const execaChildProcess = shell
       ? execaCommand(
-          isFn
-            ? command
-            : `${command} ${files.map((file) => file.replaceAll(' ', '\\ ')).join(' ')}`,
+          isFn ? command : `${command} ${files.map(escapeSpaces).join(' ')}`,
           execaOptions
         )
       : execa(cmd, isFn ? args : args.concat(files), execaOptions)

--- a/test/unit/resolveTaskFn.spec.js
+++ b/test/unit/resolveTaskFn.spec.js
@@ -120,6 +120,28 @@ describe('resolveTaskFn', () => {
     })
   })
 
+  it('shell should work with spaces in file paths', async () => {
+    expect.assertions(2)
+    const taskFn = resolveTaskFn({
+      shell: true,
+      command: 'node --arg=true ./myscript.js',
+      files: ['test file.js', 'file with/multiple spaces.js'],
+    })
+
+    await taskFn()
+    expect(execaCommand).toHaveBeenCalledTimes(1)
+    expect(execaCommand).toHaveBeenLastCalledWith(
+      'node --arg=true ./myscript.js test\\ file.js file\\ with/multiple\\ spaces.js',
+      {
+        cwd: process.cwd(),
+        preferLocal: true,
+        reject: false,
+        shell: true,
+        stdin: 'ignore',
+      }
+    )
+  })
+
   it('should pass `topLevelDir` as `cwd` to `execa()` topLevelDir !== process.cwd for git commands', async () => {
     expect.assertions(2)
     const taskFn = resolveTaskFn({


### PR DESCRIPTION
Execution of eslint using lint-staged fails when file path contains whitespaces and some workaround similar to those described in #773 is needed.

Example: For the file `/path/to/file with spaces.js`, it fails with:
```
No files matching the pattern "/path/to/file" were found.
Please check for typing mistakes in the pattern.
```

ESlint debug print contains message like this:
```
2024-12-10T06:37:22.698Z eslint:cli CLI args: [ '--config', 'eslint.config.js', '--debug', '--fix', '/path/to/file', 'with', 'spaces.js' ]
```

However, the `execa` library supports a simple space [backlash escaping](https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/command.js#L32-L37) which can be leveraged here.