### PR TITLE
feat: always save debug log file and display path on errors

### DIFF
--- a/.changeset/popular-points-boil.md
+++ b/.changeset/popular-points-boil.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': minor
+---
+
+_Lint-staged_ now always saves debug logs to a file in the OS's temp directory, and outputs the path on errors. This should make it easier to debug any errors without needing to use the `--debug` flag.

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -6,6 +6,7 @@ import { supportsColor } from 'chalk'
 import { Option, program } from 'commander'
 import debug from 'debug'
 
+import { setupDebugLogStream } from '../lib/debug.js'
 import lintStaged from '../lib/index.js'
 import { CONFIG_STDIN_ERROR, RESTORE_STASH_EXAMPLE } from '../lib/messages.js'
 import { readStdin } from '../lib/readStdin.js'
@@ -105,9 +106,8 @@ program.addHelpText('afterAll', '\n' + RESTORE_STASH_EXAMPLE)
 
 const cliOptions = program.parse(process.argv).opts()
 
-if (cliOptions.debug) {
-  debug.enable('lint-staged*')
-}
+// Seemingly setup debug twice (also done in "lib/index.js"), so that it also works when using the Node.js API
+setupDebugLogStream(cliOptions.debug)
 
 const options = {
   allowEmpty: !!cliOptions.allowEmpty,

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,47 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import util from 'node:util'
+
+import debugLib from 'debug'
+
+import { normalizePath } from './normalizePath.js'
+
+let logFile
+
+/**
+ * Setup "debug" lib to stream to a temporary file, and also
+ * to console when enabled.
+ *
+ * @type {(enabled?: boolean) => string}
+ */
+export const setupDebugLogStream = (enabled) => {
+  if (logFile) return logFile
+
+  debugLib.enable('lint-staged*')
+
+  const date = Date.now()
+  logFile = normalizePath(path.resolve(os.tmpdir(), `lint-staged-${date}.txt`))
+  const logStream = fs.createWriteStream(logFile)
+
+  /** @see {@link https://github.com/debug-js/debug/blob/7e3814cc603bf64fdd69e714e0cf5611ec31f43b/src/node.js#L194} */
+  const formatLog = (...args) =>
+    util.stripVTControlCharacters(util.formatWithOptions(debugLib.inspectOpts, ...args) + '\n')
+
+  if (enabled) {
+    const defaultLog = debugLib.log
+
+    debugLib.log = (...args) => {
+      logStream.write(formatLog(...args))
+      defaultLog(...args)
+    }
+  } else {
+    debugLib.log = (...args) => {
+      logStream.write(formatLog(...args))
+    }
+  }
+
+  debugLib('lint-staged:setupDebugLogStream')(date)
+
+  return logFile
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 import debugLib from 'debug'
 
+import { setupDebugLogStream } from './debug.js'
 import { execGit } from './execGit.js'
 import {
   GIT_ERROR,
@@ -85,10 +86,12 @@ const lintStaged = async (
   } = {},
   logger = console
 ) => {
-  // Seemingly enable debug twice (also done in bin), so that it also works when using the Node.js API
-  if (debug) {
-    debugLib.enable('lint-staged*')
+  // Seemingly setup debug twice (also done in "bin/lint-staged.js"), so that it also works when using the Node.js API
+  const logFile = setupDebugLogStream(debug)
 
+  debugLog('Streaming debug logs to file %s', logFile)
+
+  if (debug) {
     debugLog(
       'Running `lint-staged@%s` on Node.js %s (%s)',
       await getVersion(),
@@ -149,7 +152,16 @@ const lintStaged = async (
       }
 
       printTaskOutput(ctx, logger)
+
+      if (!quiet) {
+        logger.log('See debug logs for more info: %s', logFile)
+      }
+
       return false
+    }
+
+    if (!quiet) {
+      logger.log('See debug logs for more info: %s', logFile)
     }
 
     // Probably a compilation error in the config js file. Pass it up to the outer error handler for logging.

--- a/test/unit/debug.spec.js
+++ b/test/unit/debug.spec.js
@@ -1,0 +1,14 @@
+import debugLib from 'debug'
+
+import { setupDebugLogStream } from '../../lib/debug'
+
+describe('setupDebugLogStream', () => {
+  it('should override default method when enabled', () => {
+    const defaultLog = debugLib.log
+
+    setupDebugLogStream(true)
+
+    expect(debugLib.log).toBeInstanceOf(Function)
+    expect(debugLib.log).not.toEqual(defaultLog)
+  })
+})

--- a/test/unit/index2.spec.js
+++ b/test/unit/index2.spec.js
@@ -33,10 +33,8 @@ describe('lintStaged', () => {
       },
     }
 
-    expect.assertions(2)
+    expect.assertions(1)
 
     await expect(lintStaged({ config }, logger)).rejects.toThrow('failed config')
-
-    expect(logger.printHistory()).toEqual('')
   })
 })


### PR DESCRIPTION
What do you think about this @okonet? I'm not sure if there would be drawbacks to always enabling the `debug` library, I guess it would make _lint-staged_ run slightly slower? The benefit is the debug logs always exist in a file.