### PR TITLE
Add missing type definitions and `package.json` fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "type": "module",
   "bin": "./bin/lint-staged.js",
+  "types": "./lib/index.d.ts",
+  "main": "./lib/index.js",
   "exports": {
     ".": "./lib/index.js",
     "./bin": "./bin/lint-staged.js",
@@ -27,6 +29,13 @@
     "bin",
     "lib"
   ],
+  "typesVersions": {
+    "*": {
+      "bin*": [
+        "./bin/lint-staged.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "lint": "eslint .",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules npx jest --coverage",


### PR DESCRIPTION
## **This PR**:

- [X] Adds missing `package.json` fields.
- [X] Adds missing type definitions.


## Before

![lint-staged-before](https://github.com/user-attachments/assets/1d2e6922-e9e0-4967-b045-37d6ec5f5b1c)


## After

![lint-staged-after](https://github.com/user-attachments/assets/cbe129bb-899c-4275-ab42-fa0fc4b24b01)
