### PR TITLE
feat: do not reset to original state when preventing empty commit

### DIFF
--- a/.changeset/lucky-rules-teach.md
+++ b/.changeset/lucky-rules-teach.md
@@ -1,0 +1,25 @@
+---
+'lint-staged': minor
+---
+
+Lint-staged no longer resets to the original state when preventing an empty git commit. This happens when your configured tasks reset all the staged changes, typically when trying to commit formatting changes which conflict with your linter setup like ESLint or Prettier.
+
+### Example with Prettier
+
+By default Prettier [prefers double quotes](https://prettier.io/docs/rationale#strings).
+
+#### Previously
+
+1. Stage `file.js` with only double quotes `"` changed to `'`
+1. Run `git commit -am "I don't like double quotes"`
+1. _Lint-staged_ runs `prettier --write file.js`, converting all the `'` back to `"`
+1. Because there are now no changes, _lint-staged_ fails, cancels the commit, and resets back to the original state
+1. Commit was not done, original state is restored and single quotes `'` are staged
+
+#### Now
+
+1. Stage `file.js` with only double-quotes `"` changed to `'`
+1. Run `git commit -am "I don't like double quotes"`
+1. _Lint-staged_ runs `prettier --write file.js`, converting all the `'` back to `"`
+1. Because there are now no changes, _lint-staged_ fails and cancels the commit
+1. Commit was not done, and there are no staged changes

--- a/lib/state.js
+++ b/lib/state.js
@@ -2,7 +2,6 @@ import EventEmitter from 'events'
 
 import { GIT_ERROR, TASK_ERROR } from './messages.js'
 import {
-  ApplyEmptyCommitError,
   GitError,
   RestoreOriginalStateError,
   RestoreUnstagedChangesError,
@@ -49,18 +48,11 @@ export const restoreUnstagedChangesSkipped = (ctx) => {
 }
 
 export const restoreOriginalStateEnabled = (ctx) =>
-  ctx.shouldBackup &&
-  (ctx.errors.has(TaskError) ||
-    ctx.errors.has(ApplyEmptyCommitError) ||
-    ctx.errors.has(RestoreUnstagedChangesError))
+  ctx.shouldBackup && (ctx.errors.has(TaskError) || ctx.errors.has(RestoreUnstagedChangesError))
 
 export const restoreOriginalStateSkipped = (ctx) => {
   // Should be skipped in case of unknown git errors
-  if (
-    ctx.errors.has(GitError) &&
-    !ctx.errors.has(ApplyEmptyCommitError) &&
-    !ctx.errors.has(RestoreUnstagedChangesError)
-  ) {
+  if (ctx.errors.has(GitError) && !ctx.errors.has(RestoreUnstagedChangesError)) {
     return GIT_ERROR
   }
 }


### PR DESCRIPTION
See the changeset for description: [.changeset/lucky-rules-teach.md](https://github.com/lint-staged/lint-staged/blob/4c4b9f588ef52de498855e3c6095479d5998d4fc/.changeset/lucky-rules-teach.md)