### PR TITLE
fix: handle uninitialized submodules when listing staged files

### DIFF
--- a/.changeset/dry-words-talk.md
+++ b/.changeset/dry-words-talk.md
@@ -1,0 +1,9 @@
+---
+'lint-staged': patch
+---
+
+Improve listing of staged files so that _lint-staged_ doesn't crash when encountering an uninitialized submodule. This should result in less errors like:
+
+```
+✖ Failed to get staged files!
+```

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -213,7 +213,7 @@ jobs:
     name: Node.js ${{ matrix.node }} on windows-latest (Cygwin)
     runs-on: windows-latest
     steps:
-      - uses: cygwin/cygwin-install-action@v4
+      - uses: cygwin/cygwin-install-action@v5
       - run: git config --global core.autocrlf true
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/lib/getDiffCommand.js
+++ b/lib/getDiffCommand.js
@@ -1,4 +1,5 @@
-export function getDiffCommand(diff, diffFilter) {
+/** @type {(diff?: string, diffFilter?: string) => string[]} */
+export const getDiffCommand = (diff, diffFilter) => {
   /**
    *  Docs for --diff-filter option:
    * @see https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203
@@ -12,7 +13,7 @@ export function getDiffCommand(diff, diffFilter) {
    * Docs for -z option:
    * @see https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--z
    */
-  const diffCommand = ['diff', '--name-only', '-z', `--diff-filter=${diffFilterArg}`, ...diffArgs]
+  const diffCommand = ['diff', `--diff-filter=${diffFilterArg}`, ...diffArgs]
 
   return diffCommand
 }

--- a/lib/getStagedFiles.js
+++ b/lib/getStagedFiles.js
@@ -5,21 +5,51 @@ import { getDiffCommand } from './getDiffCommand.js'
 import { normalizePath } from './normalizePath.js'
 import { parseGitZOutput } from './parseGitZOutput.js'
 
-const listSubmoduleRoots = async ({ cwd }) => {
-  const lines = await execGit(['submodule', '--quiet', 'foreach', 'echo $displaypath'], { cwd })
-  return lines.split('\n').map((file) => normalizePath(path.resolve(cwd, file)))
-}
-
 export const getStagedFiles = async ({ cwd = process.cwd(), diff, diffFilter } = {}) => {
   try {
-    const lines = await execGit(getDiffCommand(diff, diffFilter), { cwd })
-    if (!lines) return []
+    /**
+     * With the raw output lines look like:
+     *
+     * :000000 100644 0000000 780ccd3\u0000A\u0000.gitmodules\u0000
+     * :000000 160000 0000000 1bb568e\u0000A\u0000submodule\u0000
+     *
+     * @see https://git-scm.com/docs/git-diff#_raw_output_format
+     */
+    const output = await execGit([...getDiffCommand(diff, diffFilter), '--raw', '-z'], { cwd })
 
-    const submodules = await listSubmoduleRoots({ cwd })
+    if (!output) return []
 
-    return parseGitZOutput(lines)
-      .map((file) => normalizePath(path.resolve(cwd, file)))
-      .filter((file) => !submodules.includes(file))
+    /**
+     * Split from all colons and remove the first one, after which lines will look like:
+     *
+     * 000000 100644 0000000 780ccd3 A\u0000.gitmodules\u0000
+     * 000000 160000 0000000 47e5cff A\u0000submodule\u0000
+     *
+     * where '\u0000' is the NUL character from '-z' option. After that we
+     * parse the lines by splitting from NUL, and then split the first
+     * part from space. This yields us enough info both filter out submodule
+     * roots and get the filename.
+     */
+    return output
+      .split(':')
+      .slice(1)
+      .map(parseGitZOutput)
+      .flatMap(([info, src, dst]) => {
+        const [, dstMode, , , ,] = info.split(' ')
+
+        /**
+         * Filter out submodule root directory. "160000" is the object mode for submodules.
+         * @see https://github.com/git/git/blob/485f5f863615e670fd97ae40af744e14072cfe18/object.h#L114-L120
+         */
+        if (dstMode === '160000') {
+          return []
+        }
+
+        /** "dst" exists when moving files, otherwise it's undefined and only "src" exists */
+        const filename = dst ?? src
+
+        return [normalizePath(path.resolve(cwd, filename))]
+      })
   } catch {
     return null
   }

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -278,7 +278,12 @@ export class GitWorkflow {
 
     debugLog('Done adding task modifications to index!')
 
-    const stagedFilesAfterAdd = await this.execGit(getDiffCommand(this.diff, this.diffFilter))
+    const stagedFilesAfterAdd = await this.execGit([
+      ...getDiffCommand(this.diff, this.diffFilter),
+      '--name-only',
+      '-z',
+    ])
+
     if (!stagedFilesAfterAdd && !this.allowEmpty) {
       // Tasks reverted all staged changes and the commit would be empty
       // Throw error to stop commit unless `--allow-empty` was used

--- a/test/unit/getDiffCommand.spec.js
+++ b/test/unit/getDiffCommand.spec.js
@@ -7,45 +7,26 @@ describe('getDiffCommand', () => {
 
   it('should default to sane value', () => {
     const diff = getDiffCommand()
-    expect(diff).toEqual(['diff', '--name-only', '-z', `--diff-filter=ACMR`, '--staged'])
+    expect(diff).toEqual(['diff', `--diff-filter=ACMR`, '--staged'])
   })
 
   it('should work only with diff set as string', () => {
     const diff = getDiffCommand(customDiffString)
-    expect(diff).toEqual([
-      'diff',
-      '--name-only',
-      '-z',
-      `--diff-filter=ACMR`,
-      'origin/main..custom-branch',
-    ])
+    expect(diff).toEqual(['diff', `--diff-filter=ACMR`, 'origin/main..custom-branch'])
   })
 
   it('should work only with diff set as space separated string', () => {
     const diff = getDiffCommand(customDiffSpaceSeparatedString)
-    expect(diff).toEqual([
-      'diff',
-      '--name-only',
-      '-z',
-      `--diff-filter=ACMR`,
-      'origin/main',
-      'custom-branch',
-    ])
+    expect(diff).toEqual(['diff', `--diff-filter=ACMR`, 'origin/main', 'custom-branch'])
   })
 
   it('should work only with diffFilter set', () => {
     const diff = getDiffCommand(undefined, customDiffFilter)
-    expect(diff).toEqual(['diff', '--name-only', '-z', `--diff-filter=a`, '--staged'])
+    expect(diff).toEqual(['diff', `--diff-filter=a`, '--staged'])
   })
 
   it('should work with both diff and diffFilter set', () => {
     const diff = getDiffCommand(customDiffString, customDiffFilter)
-    expect(diff).toEqual([
-      'diff',
-      '--name-only',
-      '-z',
-      `--diff-filter=a`,
-      'origin/main..custom-branch',
-    ])
+    expect(diff).toEqual(['diff', `--diff-filter=a`, 'origin/main..custom-branch'])
   })
 })

--- a/test/unit/getStagedFiles.spec.js
+++ b/test/unit/getStagedFiles.spec.js
@@ -20,13 +20,17 @@ describe('getStagedFiles', () => {
   })
 
   it('should return array of file names', async () => {
-    execGit.mockImplementationOnce(async () => 'foo.js\u0000bar.js\u0000')
+    execGit.mockImplementationOnce(
+      async () =>
+        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+    )
+
     const staged = await getStagedFiles({ cwd: '/' })
     // Windows filepaths
     expect(staged).toEqual([normalizeWindowsPath('/foo.js'), normalizeWindowsPath('/bar.js')])
 
     expect(execGit).toHaveBeenCalledWith(
-      ['diff', '--name-only', '-z', '--diff-filter=ACMR', '--staged'],
+      ['diff', '--diff-filter=ACMR', '--staged', '--raw', '-z'],
       { cwd: '/' }
     )
   })
@@ -45,37 +49,49 @@ describe('getStagedFiles', () => {
   })
 
   it('should support overriding diff trees with ...', async () => {
-    execGit.mockImplementationOnce(async () => 'foo.js\u0000bar.js\u0000')
+    execGit.mockImplementationOnce(
+      async () =>
+        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+    )
+
     const staged = await getStagedFiles({ cwd: '/', diff: 'main...my-branch' })
     // Windows filepaths
     expect(staged).toEqual([normalizeWindowsPath('/foo.js'), normalizeWindowsPath('/bar.js')])
 
     expect(execGit).toHaveBeenCalledWith(
-      ['diff', '--name-only', '-z', '--diff-filter=ACMR', 'main...my-branch'],
+      ['diff', '--diff-filter=ACMR', 'main...my-branch', '--raw', '-z'],
       { cwd: '/' }
     )
   })
 
   it('should support overriding diff trees with multiple args', async () => {
-    execGit.mockImplementationOnce(async () => 'foo.js\u0000bar.js\u0000')
+    execGit.mockImplementationOnce(
+      async () =>
+        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+    )
+
     const staged = await getStagedFiles({ cwd: '/', diff: 'main my-branch' })
     // Windows filepaths
     expect(staged).toEqual([normalizeWindowsPath('/foo.js'), normalizeWindowsPath('/bar.js')])
 
     expect(execGit).toHaveBeenCalledWith(
-      ['diff', '--name-only', '-z', '--diff-filter=ACMR', 'main', 'my-branch'],
+      ['diff', '--diff-filter=ACMR', 'main', 'my-branch', '--raw', '-z'],
       { cwd: '/' }
     )
   })
 
   it('should support overriding diff-filter', async () => {
-    execGit.mockImplementationOnce(async () => 'foo.js\u0000bar.js\u0000')
+    execGit.mockImplementationOnce(
+      async () =>
+        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+    )
+
     const staged = await getStagedFiles({ cwd: '/', diffFilter: 'ACDMRTUXB' })
     // Windows filepaths
     expect(staged).toEqual([normalizeWindowsPath('/foo.js'), normalizeWindowsPath('/bar.js')])
 
     expect(execGit).toHaveBeenCalledWith(
-      ['diff', '--name-only', '-z', '--diff-filter=ACDMRTUXB', '--staged'],
+      ['diff', '--diff-filter=ACDMRTUXB', '--staged', '--raw', '-z'],
       { cwd: '/' }
     )
   })


### PR DESCRIPTION
The previous command

```
git submodule foreach echo $displaypath
```

breaks when encountering uninitialized submodules, causing _lint-staged_ to crash with "_Failed to get staged files!_".

This PR improves the logic by using the `--raw` flag with `git diff` to get access to the object modes of the staged files, where mode `160000` is for the submodule directory.