### PR TITLE
feat: remove `--shell` flag support

### DIFF
--- a/.changeset/neat-parrots-watch.md
+++ b/.changeset/neat-parrots-watch.md
@@ -1,0 +1,11 @@
+---
+'lint-staged': major
+---
+
+The `--shell` flag has been removed and _lint-staged_ no longer supports evaluating commands directly via a shell. To migrate existing commands, you can create a shell script and invoke it instead. Lint-staged will pass matched staged files as a list of arguments, accessible via `"$@"`:
+
+```shell
+#!/bin/bash
+
+echo "Staged files: $@"
+```

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,33 @@
+#### v16
+
+- The lowest supported Node.js version is `18.19.0` or `20.5.0`, following requirements of `execa@9`. Please upgrade your Node.js version.
+- Advanced configuration options (removed in v9) are no longer validated separately, and might be treated as valid globs for tasks. Please do not try to use advanced config options anymore, they haven't been supported since v8.
+- The `--shell` flag has been removed and _lint-staged_ no longer supports evaluating commands directly via a shell. To migrate existing commands, you can create a shell script and invoke it instead. Lint-staged will pass matched staged files as a list of arguments, accessible via `"$@"`:
+
+#### v15
+
+- Since `v15.0.0` _lint-staged_ no longer supports Node.js 16. Please upgrade your Node.js version to at least `18.12.0`.
+
+#### v14
+
+- Since `v14.0.0` _lint-staged_ no longer supports Node.js 14. Please upgrade your Node.js version to at least `16.14.0`.
+
+#### v13
+
+- Since `v13.0.0` _lint-staged_ no longer supports Node.js 12. Please upgrade your Node.js version to at least `14.13.1`, or `16.0.0` onward.
+- Version `v13.3.0` was incorrectly released including code of version `v14.0.0`. This means the breaking changes of `v14` are also included in `v13.3.0`, the last `v13` version released
+
+#### v12
+
+- Since `v12.0.0` _lint-staged_ is a pure ESM module, so make sure your Node.js version is at least `12.20.0`, `14.13.1`, or `16.0.0`. Read more about ESM modules from the official [Node.js Documentation site here](https://nodejs.org/api/esm.html#introduction).
+
+#### v10
+
+- From `v10.0.0` onwards any new modifications to originally staged files will be automatically added to the commit.
+  If your task previously contained a `git add` step, please remove this.
+  The automatic behaviour ensures there are less race-conditions,
+  since trying to run multiple git operations at the same time usually results in an error.
+- From `v10.0.0` onwards, lint-staged uses git stashes to improve speed and provide backups while running.
+  Since git stashes require at least an initial commit, you shouldn't run lint-staged in an empty repo.
+- From `v10.0.0` onwards, lint-staged requires Node.js version 10.13.0 or later.
+- From `v10.0.0` onwards, lint-staged will abort the commit if linter tasks undo all staged changes. To allow creating an empty commit, please use the `--allow-empty` option.

--- a/README.md
+++ b/README.md
@@ -79,38 +79,7 @@ See [Releases](https://github.com/okonet/lint-staged/releases).
 
 ### Migration
 
-#### v16
-
-- The lowest supported Node.js version is `18.19.0` or `20.5.0`, following requirements of `execa@9`. Please upgrade your Node.js version.
-- Advanced configuration options (removed in v9) are no longer validated separately, and might be treated as valid globs for tasks. Please do not try to use advanced config options anymore, they haven't been supported since v8.
-
-#### v15
-
-- Since `v15.0.0` _lint-staged_ no longer supports Node.js 16. Please upgrade your Node.js version to at least `18.12.0`.
-
-#### v14
-
-- Since `v14.0.0` _lint-staged_ no longer supports Node.js 14. Please upgrade your Node.js version to at least `16.14.0`.
-
-#### v13
-
-- Since `v13.0.0` _lint-staged_ no longer supports Node.js 12. Please upgrade your Node.js version to at least `14.13.1`, or `16.0.0` onward.
-- Version `v13.3.0` was incorrectly released including code of version `v14.0.0`. This means the breaking changes of `v14` are also included in `v13.3.0`, the last `v13` version released
-
-#### v12
-
-- Since `v12.0.0` _lint-staged_ is a pure ESM module, so make sure your Node.js version is at least `12.20.0`, `14.13.1`, or `16.0.0`. Read more about ESM modules from the official [Node.js Documentation site here](https://nodejs.org/api/esm.html#introduction).
-
-#### v10
-
-- From `v10.0.0` onwards any new modifications to originally staged files will be automatically added to the commit.
-  If your task previously contained a `git add` step, please remove this.
-  The automatic behaviour ensures there are less race-conditions,
-  since trying to run multiple git operations at the same time usually results in an error.
-- From `v10.0.0` onwards, lint-staged uses git stashes to improve speed and provide backups while running.
-  Since git stashes require at least an initial commit, you shouldn't run lint-staged in an empty repo.
-- From `v10.0.0` onwards, lint-staged requires Node.js version 10.13.0 or later.
-- From `v10.0.0` onwards, lint-staged will abort the commit if linter tasks undo all staged changes. To allow creating an empty commit, please use the `--allow-empty` option.
+For breaking changes, see [MIGRATION.md](./MIGRATION.md).
 
 ## Command line flags
 
@@ -136,7 +105,6 @@ Options:
   --no-hide-partially-staged         disable hiding unstaged changes from partially staged files
   -q, --quiet                        disable lint-staged’s own console output (default: false)
   -r, --relative                     pass relative filepaths to tasks (default: false)
-  -x, --shell [path]                 skip parsing of tasks for better shell support (default: false)
   -v, --verbose                      show task output even when tasks succeed; by default only failed output is
                                      shown (default: false)
   -h, --help                         display help for command
@@ -167,7 +135,6 @@ Any lost modifications can be restored from a git stash:
 - **`--no-hide-partially-staged`**: By default, unstaged changes from partially staged files will be hidden. This option will disable this behavior and include all unstaged changes in partially staged files. Can be re-enabled with `--hide-partially-staged`
 - **`--quiet`**: Supress all CLI output, except from tasks.
 - **`--relative`**: Pass filepaths relative to `process.cwd()` (where `lint-staged` runs) to tasks. Default is `false`.
-- **`--shell`**: By default task commands will be parsed for speed and security. This has the side-effect that regular shell scripts might not work as expected. You can skip parsing of commands with this option. To use a specific shell, use a path like `--shell "/bin/bash"`.
 - **`--verbose`**: Show task output even when tasks succeed. By default only failed output is shown.
 
 ## Configuration
@@ -784,7 +751,6 @@ const success = await lintStaged({
   maxArgLength: null,
   quiet: false,
   relative: false,
-  shell: false,
   stash: true,
   verbose: false,
 })
@@ -802,7 +768,6 @@ const success = await lintStaged({
   maxArgLength: null,
   quiet: false,
   relative: false,
-  shell: false,
   stash: true,
   verbose: false,
 })
@@ -1035,18 +1000,10 @@ See issue [#825](https://github.com/okonet/lint-staged/issues/825) for more deta
 
 #### Root Cause
 
-<details>
-  <summary>Click to expand</summary>
-
 1. `lint-staged` automatically passes matched staged files as arguments to commands.
 2. Certain input files can cause TypeScript to ignore `tsconfig.json`. For more details, see this TypeScript issue: [Allow tsconfig.json when input files are specified](https://github.com/microsoft/TypeScript/issues/27379).
 
-</details>
-
-#### Workaround 1: Use a [function signature](https://github.com/lint-staged/lint-staged?tab=readme-ov-file#example-run-tsc-on-changes-to-typescript-files-but-do-not-pass-any-filename-arguments) for the `tsc` command
-
-<details>
-  <summary>Click to expand</summary>
+#### Workaround: Use a [function signature](https://github.com/lint-staged/lint-staged?tab=readme-ov-file#example-run-tsc-on-changes-to-typescript-files-but-do-not-pass-any-filename-arguments) for the `tsc` command
 
 As suggested by @antoinerousseau in [#825 (comment)](https://github.com/lint-staged/lint-staged/issues/825#issuecomment-620018284), using a function prevents `lint-staged` from appending file arguments:
 
@@ -1071,44 +1028,5 @@ module.exports = {
   '*.{ts,tsx}': [() => 'tsc --noEmit', 'prettier --write'],
 }
 ```
-
-</details>
-
-#### Workaround 2: Take the `sh` or `bash` to wrap the `tsc` command
-
-<details>
-  <summary>Click to expand</summary>
-
-As suggested by @sombreroEnPuntas in [#825 (comment)](https://github.com/lint-staged/lint-staged/issues/825#issuecomment-674575655), wrapping `tsc` in a shell command prevents `lint-staged` from modifying its arguments:
-
-**Before:**
-
-```js
-// package.json
-
-"lint-staged": {
-  "*.{ts,tsx}":[
-    "tsc --noEmit",
-    "prettier --write"
-  ]
-}
-```
-
-**After:**
-
-```js
-// package.json
-
-"lint-staged": {
-  "*.{ts,tsx}":[
-    "bash -c 'tsc --noEmit'"
-    "prettier --write"
-  ]
-}
-```
-
-**Note:** This approach may have cross-platform compatibility issues.
-
-</details>
 
 </details>

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -108,8 +108,6 @@ program.option('-q, --quiet', 'disable lint-staged’s own console output', fals
 
 program.option('-r, --relative', 'pass relative filepaths to tasks', false)
 
-program.option('-x, --shell [path]', 'skip parsing of tasks for better shell support', false)
-
 program.option(
   '-v, --verbose',
   'show task output even when tasks succeed; by default only failed output is shown',
@@ -136,7 +134,6 @@ const options = {
   maxArgLength: cliOptions.maxArgLength || undefined,
   quiet: !!cliOptions.quiet,
   relative: !!cliOptions.relative,
-  shell: cliOptions.shell /* Either a boolean or a string pointing to the shell */,
   stash: !!cliOptions.stash, // commander inverts `no-<x>` flags to `!x`
   hidePartiallyStaged: !!cliOptions.hidePartiallyStaged, // commander inverts `no-<x>` flags to `!x`
   verbose: !!cliOptions.verbose,

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -62,11 +62,6 @@ export type Options = {
    */
   relative?: boolean
   /**
-   * Skip parsing of tasks for better shell support
-   * @default false
-   */
-  shell?: boolean
-  /**
    * Enable the backup stash, and revert in case of errors.
    * @warn Disabling this also implies `hidePartiallyStaged: false`.
    * @default true

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,6 @@ const getMaxArgLength = () => {
  * @param {number} [options.maxArgLength] - Maximum argument string length
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
- * @param {boolean|string} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
  * @param {Logger} [logger]
@@ -79,7 +78,6 @@ const lintStaged = async (
     maxArgLength = getMaxArgLength() / 2,
     quiet = false,
     relative = false,
-    shell = false,
     // Stashing should be disabled by default when the `diff` option is used
     stash = diff === undefined,
     hidePartiallyStaged = stash,
@@ -115,7 +113,6 @@ const lintStaged = async (
     maxArgLength,
     quiet,
     relative,
-    shell,
     stash,
     hidePartiallyStaged,
     verbose,

--- a/lib/makeCmdTasks.js
+++ b/lib/makeCmdTasks.js
@@ -13,10 +13,9 @@ const debugLog = debug('lint-staged:makeCmdTasks')
  * @param {string} options.cwd
  * @param {Array<string>} options.files
  * @param {string} options.topLevelDir
- * @param {Boolean} shell
  * @param {Boolean} verbose
  */
-export const makeCmdTasks = async ({ commands, cwd, files, topLevelDir, shell, verbose }) => {
+export const makeCmdTasks = async ({ commands, cwd, files, topLevelDir, verbose }) => {
   debugLog('Creating listr tasks for commands %o', commands)
   const commandArray = Array.isArray(commands) ? commands : [commands]
   const cmdTasks = []
@@ -43,7 +42,7 @@ export const makeCmdTasks = async ({ commands, cwd, files, topLevelDir, shell, v
         )
       }
 
-      const task = resolveTaskFn({ command, cwd, files, topLevelDir, isFn, shell, verbose })
+      const task = resolveTaskFn({ command, cwd, files, topLevelDir, isFn, verbose })
       cmdTasks.push({ title: command, command, task })
     }
   }

--- a/lib/resolveTaskFn.js
+++ b/lib/resolveTaskFn.js
@@ -1,17 +1,12 @@
 import chalk from 'chalk'
 import debug from 'debug'
-import { execa, execaCommand } from 'execa'
+import { execa } from 'execa'
 import pidTree from 'pidtree'
 import { parseArgsStringToArgv } from 'string-argv'
 
 import { error, info } from './figures.js'
 import { getInitialState } from './state.js'
 import { TaskError } from './symbols.js'
-
-/**
- * @see https://github.com/sindresorhus/execa/blob/f4b8b3ab601c94d1503f1010822952758dcc6350/lib/command.js#L32-L37
- */
-const escapeSpaces = (input) => input.replaceAll(' ', '\\ ')
 
 const TASK_ERROR = 'lint-staged:taskError'
 
@@ -134,7 +129,6 @@ const makeErr = (command, result, ctx) => {
  * @param {String} options.topLevelDir - Current git repo top-level path
  * @param {Boolean} options.isFn - Whether the linter task is a function
  * @param {Array<string>} options.files — Filepaths to run the linter task against
- * @param {Boolean} [options.shell] — Whether to skip parsing linter task for better shell support
  * @param {Boolean} [options.verbose] — Always show task verbose
  * @returns {() => Promise<Array<string>>}
  */
@@ -144,7 +138,6 @@ export const resolveTaskFn = ({
   files,
   topLevelDir,
   isFn,
-  shell = false,
   verbose = false,
 }) => {
   const [cmd, ...args] = parseArgsStringToArgv(command)
@@ -157,19 +150,13 @@ export const resolveTaskFn = ({
     cwd: /^git(\.exe)?/i.test(cmd) ? topLevelDir : cwd,
     preferLocal: true,
     reject: false,
-    shell,
     stdin: 'ignore',
   }
 
   debugLog('execaOptions:', execaOptions)
 
   return async (ctx = getInitialState()) => {
-    const execaChildProcess = shell
-      ? execaCommand(
-          isFn ? command : `${command} ${files.map(escapeSpaces).join(' ')}`,
-          execaOptions
-        )
-      : execa(cmd, isFn ? args : args.concat(files), execaOptions)
+    const execaChildProcess = execa(cmd, isFn ? args : args.concat(files), execaOptions)
 
     const quitInterruptCheck = interruptExecutionOnError(ctx, execaChildProcess)
     const result = await execaChildProcess

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -59,7 +59,6 @@ const createError = (ctx) => Object.assign(new Error('lint-staged failed'), { ct
  * @param {number} [options.maxArgLength] - Maximum argument string length
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
- * @param {boolean} [options.shell] - Skip parsing of tasks for better shell support
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
  * @param {Logger} logger
@@ -79,7 +78,6 @@ export const runAll = async (
     maxArgLength,
     quiet = false,
     relative = false,
-    shell = false,
     // Stashing should be disabled by default when the `diff` option is used
     stash = diff === undefined,
     hidePartiallyStaged = stash,
@@ -199,7 +197,6 @@ export const runAll = async (
             cwd: groupCwd,
             files: task.fileList,
             topLevelDir,
-            shell,
             verbose,
           }).then((subTasks) => {
             // Add files from task to match set

--- a/lib/validateOptions.js
+++ b/lib/validateOptions.js
@@ -13,8 +13,6 @@ const debugLog = debug('lint-staged:validateOptions')
  * Validate lint-staged options, either from the Node.js API or the command line flags.
  * @param {*} options
  * @param {boolean|string} [options.cwd] - Current working directory
- * @param {boolean|string} [options.shell] - Skip parsing of tasks for better shell support
- *
  * @throws {InvalidOptionsError}
  */
 export const validateOptions = async (options = {}, logger) => {
@@ -28,17 +26,6 @@ export const validateOptions = async (options = {}, logger) => {
     } catch (error) {
       debugLog('Failed to validate options: %o', options)
       logger.error(invalidOption('cwd', options.cwd, error.message))
-      throw InvalidOptionsError
-    }
-  }
-
-  /** Ensure the passed shell option is executable */
-  if (typeof options.shell === 'string') {
-    try {
-      await fs.access(options.shell, constants.X_OK)
-    } catch (error) {
-      debugLog('Failed to validate options: %o', options)
-      logger.error(invalidOption('shell', options.shell, error.message))
       throw InvalidOptionsError
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,8 +33,9 @@
     "./package.json": "./package.json"
   },
   "files": [
-    "bin",
-    "lib"
+    "bin/",
+    "lib/",
+    "MIGRATION.md"
   ],
   "scripts": {
     "lint": "eslint .",

--- a/test/integration/git-lock-file.test.js
+++ b/test/integration/git-lock-file.test.js
@@ -26,7 +26,6 @@ describe('lint-staged', () => {
       await expect(
         gitCommit({
           lintStaged: {
-            shell: isWindows,
             config: {
               '*.js': (files) => [
                 `${isWindows ? 'type nul >' : 'touch'} ${cwd}/.git/index.lock`,

--- a/test/integration/multiple-config-files.test.js
+++ b/test/integration/multiple-config-files.test.js
@@ -29,8 +29,7 @@ describe('lint-staged', () => {
       // Stage all files
       await execGit(['add', '.'])
 
-      // Run lint-staged with `--shell` so that tasks do their thing
-      await gitCommit({ lintStaged: { shell: true } })
+      await gitCommit()
 
       // 'file.js' matched '.lintstagedrc.json'
       expect(await readFile('file.js')).toMatch('level-0')
@@ -68,8 +67,7 @@ describe('lint-staged', () => {
       // Stage all files
       await execGit(['add', '.'])
 
-      // Run lint-staged with `--shell` so that tasks do their thing
-      await gitCommit({ lintStaged: { relative: true, shell: true } })
+      await gitCommit({ lintStaged: { relative: true } })
 
       // 'file.js' is relative to '.'
       expect(await readFile('file.js')).toMatch('file.js')
@@ -110,9 +108,8 @@ describe('lint-staged', () => {
       // Stage all files
       await execGit(['add', '.'])
 
-      // Run lint-staged with `--shell` so that tasks do their thing
       // Run in 'deeper/' so that root config is ignored
-      await gitCommit({ lintStaged: { shell: true } }, path.join(cwd, 'deeper'))
+      await gitCommit(undefined, path.join(cwd, 'deeper'))
 
       // 'file.js' was ignored
       expect(await readFile('file.js')).toEqual('')

--- a/test/integration/parent-globs.test.js
+++ b/test/integration/parent-globs.test.js
@@ -27,9 +27,8 @@ describe('lint-staged', () => {
       // Stage all files
       await execGit(['add', '.'])
 
-      // Run lint-staged with `--shell` so that tasks do their thing
       // Run in 'deeper/' so that root config is ignored
-      await gitCommit({ lintStaged: { shell: true } }, path.join(cwd, 'deeper/even'))
+      await gitCommit(undefined, path.join(cwd, 'deeper/even'))
 
       // Two levels above, no match
       expect(await readFile('file.js')).toEqual('')

--- a/test/unit/makeCmdTasks.spec.js
+++ b/test/unit/makeCmdTasks.spec.js
@@ -48,7 +48,6 @@ describe('makeCmdTasks', () => {
       cwd: process.cwd(),
       preferLocal: true,
       reject: false,
-      shell: false,
       stdin: 'ignore',
     })
     taskPromise = linter2.task()
@@ -59,7 +58,6 @@ describe('makeCmdTasks', () => {
       cwd: process.cwd(),
       preferLocal: true,
       reject: false,
-      shell: false,
       stdin: 'ignore',
     })
   })

--- a/test/unit/resolveTaskFn.spec.js
+++ b/test/unit/resolveTaskFn.spec.js
@@ -38,7 +38,6 @@ describe('resolveTaskFn', () => {
       cwd: process.cwd(),
       preferLocal: true,
       reject: false,
-      shell: false,
       stdin: 'ignore',
     })
   })
@@ -57,89 +56,8 @@ describe('resolveTaskFn', () => {
       cwd: process.cwd(),
       preferLocal: true,
       reject: false,
-      shell: false,
       stdin: 'ignore',
     })
-  })
-
-  it('should not append pathsToLint when isFn and shell', async () => {
-    expect.assertions(2)
-    const taskFn = resolveTaskFn({
-      ...defaultOpts,
-      isFn: true,
-      shell: true,
-      command: 'node --arg=true ./myscript.js test.js',
-    })
-
-    await taskFn()
-    expect(execaCommand).toHaveBeenCalledTimes(1)
-    expect(execaCommand).toHaveBeenLastCalledWith('node --arg=true ./myscript.js test.js', {
-      cwd: process.cwd(),
-      preferLocal: true,
-      reject: false,
-      shell: true,
-      stdin: 'ignore',
-    })
-  })
-
-  it('should work with shell', async () => {
-    expect.assertions(2)
-    const taskFn = resolveTaskFn({
-      ...defaultOpts,
-      shell: true,
-      command: 'node --arg=true ./myscript.js',
-    })
-
-    await taskFn()
-    expect(execaCommand).toHaveBeenCalledTimes(1)
-    expect(execaCommand).toHaveBeenLastCalledWith('node --arg=true ./myscript.js test.js', {
-      cwd: process.cwd(),
-      preferLocal: true,
-      reject: false,
-      shell: true,
-      stdin: 'ignore',
-    })
-  })
-
-  it('should work with path to custom shell', async () => {
-    expect.assertions(2)
-    const taskFn = resolveTaskFn({
-      ...defaultOpts,
-      shell: '/bin/bash',
-      command: 'node --arg=true ./myscript.js',
-    })
-
-    await taskFn()
-    expect(execaCommand).toHaveBeenCalledTimes(1)
-    expect(execaCommand).toHaveBeenLastCalledWith('node --arg=true ./myscript.js test.js', {
-      cwd: process.cwd(),
-      preferLocal: true,
-      reject: false,
-      shell: '/bin/bash',
-      stdin: 'ignore',
-    })
-  })
-
-  it('shell should work with spaces in file paths', async () => {
-    expect.assertions(2)
-    const taskFn = resolveTaskFn({
-      shell: true,
-      command: 'node --arg=true ./myscript.js',
-      files: ['test file.js', 'file with/multiple spaces.js'],
-    })
-
-    await taskFn()
-    expect(execaCommand).toHaveBeenCalledTimes(1)
-    expect(execaCommand).toHaveBeenLastCalledWith(
-      'node --arg=true ./myscript.js test\\ file.js file\\ with/multiple\\ spaces.js',
-      {
-        cwd: process.cwd(),
-        preferLocal: true,
-        reject: false,
-        shell: true,
-        stdin: 'ignore',
-      }
-    )
   })
 
   it('should pass `topLevelDir` as `cwd` to `execa()` topLevelDir !== process.cwd for git commands', async () => {
@@ -156,7 +74,6 @@ describe('resolveTaskFn', () => {
       cwd: '../',
       preferLocal: true,
       reject: false,
-      shell: false,
       stdin: 'ignore',
     })
   })
@@ -171,7 +88,6 @@ describe('resolveTaskFn', () => {
       cwd: process.cwd(),
       preferLocal: true,
       reject: false,
-      shell: false,
       stdin: 'ignore',
     })
   })

--- a/test/unit/resolveTaskFn.unmocked.spec.js
+++ b/test/unit/resolveTaskFn.unmocked.spec.js
@@ -2,17 +2,6 @@ import { resolveTaskFn } from '../../lib/resolveTaskFn.js'
 import { getInitialState } from '../../lib/state.js'
 
 describe('resolveTaskFn', () => {
-  it('should call execa with shell when configured so', async () => {
-    const taskFn = resolveTaskFn({
-      command: 'node -e "process.exit(1)" || echo $?',
-      files: ['package.json'],
-      isFn: true,
-      shell: true,
-    })
-
-    await expect(taskFn()).resolves.toMatchInlineSnapshot(`undefined`)
-  })
-
   it('should kill a long running task when another fails', async () => {
     const context = getInitialState()
 

--- a/test/unit/validateOptions.spec.js
+++ b/test/unit/validateOptions.spec.js
@@ -82,48 +82,4 @@ describe('validateOptions', () => {
       `)
     })
   })
-
-  describe('shell', () => {
-    it('should resolve with valid string-valued shell option', async () => {
-      expect.assertions(4)
-
-      const logger = makeConsoleMock()
-
-      mockAccess.mockImplementationOnce(async () => {})
-
-      await expect(validateOptions({ shell: '/bin/sh' }, logger)).resolves.toBeUndefined()
-
-      expect(mockAccess).toHaveBeenCalledTimes(1)
-      expect(mockAccess).toHaveBeenCalledWith('/bin/sh', constants.X_OK)
-
-      expect(logger.history()).toHaveLength(0)
-    })
-
-    it('should reject with invalid string-valued shell option', async () => {
-      expect.assertions(5)
-
-      const logger = makeConsoleMock()
-
-      mockAccess.mockImplementationOnce(() => Promise.reject(new Error('Failed')))
-
-      await expect(validateOptions({ shell: '/bin/sh' }, logger)).rejects.toThrow(
-        InvalidOptionsError
-      )
-
-      expect(mockAccess).toHaveBeenCalledTimes(1)
-      expect(mockAccess).toHaveBeenCalledWith('/bin/sh', constants.X_OK)
-
-      expect(logger.history()).toHaveLength(1)
-      expect(logger.printHistory()).toMatchInlineSnapshot(`
-        "
-        ERROR ✖ Validation Error:
-
-          Invalid value for option 'shell': /bin/sh
-
-          Failed
-
-        See https://github.com/okonet/lint-staged#command-line-flags"
-      `)
-    })
-  })
 })


### PR DESCRIPTION
Parsing shell commands is unsafe, and I don't think _lint-staged_ needs to directly support it. Users can create a wrapper shell script instead (or even a JS script), since _lint-staged_ passed the matched staged files as arguments anyway:

```shell
#!/bin/bash

echo "Staged files: $@"
```
