### PR TITLE
fix: handle colon characters in staged filenames

### DIFF
--- a/.changeset/happy-cougars-wish.md
+++ b/.changeset/happy-cougars-wish.md
@@ -2,4 +2,4 @@
 'lint-staged': patch
 ---
 
-Handles colon characters in staged filenames.
+Correctly handle colon (`:`) characters in staged filenames.

--- a/.changeset/happy-cougars-wish.md
+++ b/.changeset/happy-cougars-wish.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Handles colon characters in staged filenames.

--- a/lib/getStagedFiles.js
+++ b/lib/getStagedFiles.js
@@ -31,8 +31,8 @@ export const getStagedFiles = async ({ cwd = process.cwd(), diff, diffFilter } =
      * roots and get the filename.
      */
     return output
-      .split(':')
       .slice(1)
+      .split('\u0000:')
       .map(parseGitZOutput)
       .flatMap(([info, src, dst]) => {
         const [, dstMode, , , ,] = info.split(' ')

--- a/test/unit/getStagedFiles.spec.js
+++ b/test/unit/getStagedFiles.spec.js
@@ -22,12 +22,28 @@ describe('getStagedFiles', () => {
   it('should return array of file names', async () => {
     execGit.mockImplementationOnce(
       async () =>
-        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+        ':000000 100644 0000000 0000000 A\u0000foo.js\u0000:000000 100644 0000000 0000000 A\u0000bar.js\u0000'
     )
 
     const staged = await getStagedFiles({ cwd: '/' })
     // Windows filepaths
     expect(staged).toEqual([normalizeWindowsPath('/foo.js'), normalizeWindowsPath('/bar.js')])
+
+    expect(execGit).toHaveBeenCalledWith(
+      ['diff', '--diff-filter=ACMR', '--staged', '--raw', '-z'],
+      { cwd: '/' }
+    )
+  })
+
+  it('should allow colons in file names', async () => {
+    execGit.mockImplementationOnce(
+      async () =>
+        ':000000 100644 0000000 0000000 A\u0000foo.js\u0000:000000 100644 0000000 0000000 A\u0000bar:qux.js\u0000'
+    )
+
+    const staged = await getStagedFiles({ cwd: '/' })
+    // Windows filepaths
+    expect(staged).toEqual([normalizeWindowsPath('/foo.js'), normalizeWindowsPath('/bar:qux.js')])
 
     expect(execGit).toHaveBeenCalledWith(
       ['diff', '--diff-filter=ACMR', '--staged', '--raw', '-z'],
@@ -51,7 +67,7 @@ describe('getStagedFiles', () => {
   it('should support overriding diff trees with ...', async () => {
     execGit.mockImplementationOnce(
       async () =>
-        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+        ':000000 100644 0000000 0000000 A\u0000foo.js\u0000:000000 100644 0000000 0000000 A\u0000bar.js\u0000'
     )
 
     const staged = await getStagedFiles({ cwd: '/', diff: 'main...my-branch' })
@@ -67,7 +83,7 @@ describe('getStagedFiles', () => {
   it('should support overriding diff trees with multiple args', async () => {
     execGit.mockImplementationOnce(
       async () =>
-        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+        ':000000 100644 0000000 0000000 A\u0000foo.js\u0000:000000 100644 0000000 0000000 A\u0000bar.js\u0000'
     )
 
     const staged = await getStagedFiles({ cwd: '/', diff: 'main my-branch' })
@@ -83,7 +99,7 @@ describe('getStagedFiles', () => {
   it('should support overriding diff-filter', async () => {
     execGit.mockImplementationOnce(
       async () =>
-        ':000000 100644 0000000 0000000 A\u0000foo.js:000000 100644 0000000 0000000 A\u0000bar.js'
+        ':000000 100644 0000000 0000000 A\u0000foo.js\u0000:000000 100644 0000000 0000000 A\u0000bar.js\u0000'
     )
 
     const staged = await getStagedFiles({ cwd: '/', diffFilter: 'ACDMRTUXB' })


### PR DESCRIPTION
After upgrading `lint-staged` to `v15.5.1`, it keeps throwing `Failed to get staged files!` for me. Did some debugging and realised that it does not support filenames with colon any more. 

Potentially fixing #1543.