### PR TITLE
feat: leave out symlinks from list of staged files

### DIFF
--- a/.changeset/yummy-poems-agree.md
+++ b/.changeset/yummy-poems-agree.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': minor
+---
+
+_Lint-staged_ now ignores symlinks and leaves them out from the list of staged files.

--- a/lib/getStagedFiles.js
+++ b/lib/getStagedFiles.js
@@ -38,10 +38,10 @@ export const getStagedFiles = async ({ cwd = process.cwd(), diff, diffFilter } =
         const [, dstMode, , , ,] = info.split(' ')
 
         /**
-         * Filter out submodule root directory. "160000" is the object mode for submodules.
-         * @see https://github.com/git/git/blob/485f5f863615e670fd97ae40af744e14072cfe18/object.h#L114-L120
+         * Filter out submodules and symlinks
+         * @see https://github.com/git/git/blob/cb96e1697ad6e54d11fc920c95f82977f8e438f8/Documentation/git-fast-import.adoc?plain=1#L634-L646
          */
-        if (dstMode === '160000') {
+        if (dstMode === '160000' || dstMode === '120000') {
           return []
         }
 

--- a/test/integration/symlinked-staged-files.test.js
+++ b/test/integration/symlinked-staged-files.test.js
@@ -1,0 +1,40 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+import { expect, jest } from '@jest/globals'
+
+import * as configFixtures from './__fixtures__/configs.js'
+import * as fileFixtures from './__fixtures__/files.js'
+import { withGitIntegration } from './__utils__/withGitIntegration.js'
+
+jest.setTimeout(20000)
+jest.retryTimes(2)
+
+describe('lint-staged', () => {
+  test(
+    'ignores symlinked staged files',
+    withGitIntegration(async ({ appendFile, cwd, execGit, gitCommit, readFile }) => {
+      await appendFile('test.js', fileFixtures.uglyJS)
+      await appendFile('.lintstagedrc.json', JSON.stringify(configFixtures.prettierListDifferent))
+
+      await execGit(['add', '.'])
+
+      /** lint-staged fails to ugly staged file */
+      await expect(gitCommit()).rejects.toThrow('prettier --list-different')
+
+      await execGit(['commit', '-m "commit without lint-staged"'])
+
+      await fs.symlink(path.join(cwd, 'test.js'), path.join(cwd, 'test_2.js'))
+
+      /** stage symlink to ugly file*/
+      await execGit(['add', '.'])
+      expect(await execGit(['status'])).toMatch('new file:   test_2.js')
+      expect(await readFile('test_2.js')).toEqual(fileFixtures.uglyJS)
+
+      const result = await gitCommit()
+
+      /** lint-staged ignored symlink */
+      expect(result).toMatch('No staged files found')
+    })
+  )
+})


### PR DESCRIPTION
Symlinks themselves aren't really relevant "staged files", because the actual file contents are elsewhere. Previously linters probably either resolved to the absolute path themselves, or errored out.

Now that we use the Git Diff raw output since https://github.com/lint-staged/lint-staged/pull/1533, we can filter them out.