### PR TITLE
Hide unstaged and untracked files

### DIFF
--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -74,10 +74,10 @@ program
   .addOption(
     new Option(
       '--no-stash',
-      'disable the backup stash, and do not revert in case of errors. Implies "--no-hide-partially-staged".'
+      'disable the backup stash, and do not revert in case of errors. Implies "--no-hide-partially-staged", "--no-hide-unstaged", and "--no-hide-untracked".'
     )
       .default(false)
-      .implies({ hidePartiallyStaged: false })
+      .implies({ hidePartiallyStaged: false, hideUnstaged: false, hideUntracked: false })
   )
 
 /**
@@ -96,6 +96,18 @@ program
       '--no-hide-partially-staged',
       'disable hiding unstaged changes from partially staged files'
     ).default(false)
+  )
+
+program
+  .addOption(new Option('--hide-unstaged', 'hide unstaged files').default(false))
+  .addOption(
+    new Option('--no-hide-unstaged', 'disable hiding unstaged files').default(true).hideHelp()
+  )
+
+program
+  .addOption(new Option('--hide-untracked', 'hide untracked files').default(false))
+  .addOption(
+    new Option('--no-hide-untracked', 'disable hiding untracked files').default(true).hideHelp()
   )
 
 program.option('-q, --quiet', 'disable lint-staged’s own console output', false)
@@ -129,6 +141,8 @@ const options = {
   relative: !!cliOptions.relative,
   stash: !!cliOptions.stash, // commander inverts `no-<x>` flags to `!x`
   hidePartiallyStaged: !!cliOptions.hidePartiallyStaged, // commander inverts `no-<x>` flags to `!x`
+  hideUnstaged: !!cliOptions.hideUnstaged,
+  hideUntracked: !!cliOptions.hideUntracked,
   verbose: !!cliOptions.verbose,
 }
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -51,3 +51,13 @@ export const writeFile = async (filename, buffer) => {
   debugLog('Writing file `%s`', filename)
   await fs.writeFile(filename, buffer)
 }
+
+/**
+ * Rename file or directory
+ * @param {String} sourcePath
+ * @param {String} destinationPath
+ */
+export const rename = async (sourcePath, destinationPath) => {
+  debugLog('Renaming file `%s` to `%s`', sourcePath, destinationPath)
+  await fs.rename(sourcePath, destinationPath)
+}

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,3 +1,4 @@
+import fsSync from 'node:fs'
 import fs from 'node:fs/promises'
 
 import debug from 'debug'
@@ -60,4 +61,13 @@ export const writeFile = async (filename, buffer) => {
 export const rename = async (sourcePath, destinationPath) => {
   debugLog('Renaming file `%s` to `%s`', sourcePath, destinationPath)
   await fs.rename(sourcePath, destinationPath)
+}
+
+/**
+ * Create directory
+ * @param {String} directory
+ */
+export const mkdirSync = (directory) => {
+  debugLog('Creating directory `%s`', directory)
+  fsSync.mkdirSync(directory, { recursive: true })
 }

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -238,7 +238,7 @@ export class GitWorkflow {
     try {
       debugLog(task.title)
 
-      // Get a list of files with bot staged and unstaged changes.
+      // Get a list of files with both staged and unstaged changes.
       // Unstaged changes to these files should be hidden before the tasks run.
       this.partiallyStagedFiles = await this.getPartiallyStagedFiles()
 

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -1,10 +1,9 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
 import debug from 'debug'
 
 import { execGit } from './execGit.js'
-import { readFile, rename, unlink, writeFile } from './file.js'
+import { mkdirSync, readFile, rename, unlink, writeFile } from './file.js'
 import { getDiffCommand } from './getDiffCommand.js'
 import {
   ApplyEmptyCommitError,
@@ -91,7 +90,7 @@ export class GitWorkflow {
    */
   getHiddenDirectory() {
     const directory = path.resolve(this.gitConfigDir, '.lint-staged')
-    fs.mkdirSync(directory, { recursive: true })
+    mkdirSync(directory)
     return directory
   }
 

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import debug from 'debug'
@@ -90,7 +91,9 @@ export class GitWorkflow {
    * @param {string} filename
    */
   getHiddenFilepath(filename) {
-    return path.resolve(this.gitConfigDir, `./${filename}`)
+    const dir = path.resolve(this.gitConfigDir, '.lint-staged')
+    fs.mkdirSync(dir, { recursive: true })
+    return path.resolve(dir, `./${filename}`)
   }
 
   /**
@@ -162,6 +165,7 @@ export class GitWorkflow {
   }
 
   /**
+   * TODO: also unstaged
    * Get a list of all files with both staged and unstaged modifications.
    * Renames have special treatment, since the single status line includes
    * both the "from" and "to" filenames, where "from" is no longer on disk.
@@ -183,12 +187,41 @@ export class GitWorkflow {
       .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
       .filter((line) => {
         const [index, workingTree] = line
+        // TODO: ....
         return index !== ' ' && workingTree !== ' ' && index !== '?' && workingTree !== '?'
       })
       .map((line) => line.substr(3)) // Remove first three letters (index, workingTree, and a whitespace)
       .filter(Boolean) // Filter empty string
     debugLog('Found partially staged files:', partiallyStaged)
     return partiallyStaged.length ? partiallyStaged : null
+  }
+
+  /**
+   * TODO: ...
+   */
+  async getUntrackedFiles() {
+    debugLog('Getting untracked files...')
+    const status = await this.execGit(['status', '-z'])
+    /**
+     * See https://git-scm.com/docs/git-status#_short_format
+     * Entries returned in machine format are separated by a NUL character.
+     * The first letter of each entry represents current index status,
+     * and second the working tree. Index and working tree status codes are
+     * separated from the file name by a space. If an entry includes a
+     * renamed file, the file names are separated by a NUL character
+     * (e.g. `to`\0`from`)
+     */
+    const untracked = status
+      // eslint-disable-next-line no-control-regex
+      .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
+      .filter((line) => {
+        const [index, workingTree] = line
+        return index === '?' && workingTree === '?'
+      })
+      .map((line) => line.substr(3)) // Remove first three letters (index, workingTree, and a whitespace)
+      .filter(Boolean) // Filter empty string
+    debugLog('Found untracked files:', untracked)
+    return untracked.length ? untracked : null
   }
 
   /**
@@ -209,6 +242,21 @@ export class GitWorkflow {
         await this.execGit(['diff', ...GIT_DIFF_ARGS, '--output', unstagedPatch, '--', ...files])
       } else {
         ctx.hasPartiallyStagedFiles = false
+      }
+
+      this.untrackedFiles = await this.getUntrackedFiles()
+
+      if (this.untrackedFiles) {
+        ctx.hasUntrackedFiles = true
+
+        // for (const file of this.untrackedFiles ?? []) {
+        //   await fs.promises.rename(
+        //     path.resolve(this.topLevelDir, file),
+        //     this.getHiddenFilepath(file)
+        //   )
+        // }
+      } else {
+        ctx.hasUntrackedFiles = false
       }
 
       /**
@@ -258,6 +306,12 @@ export class GitWorkflow {
        * If this does fail, the handleError method will set ctx.gitError and lint-staged will fail.
        */
       handleError(error, ctx, HideUnstagedChangesError)
+    }
+  }
+
+  async hideUntrackedFiles() {
+    for (const file of this.untrackedFiles ?? []) {
+      await fs.promises.rename(path.resolve(this.topLevelDir, file), this.getHiddenFilepath(file))
     }
   }
 
@@ -320,6 +374,12 @@ export class GitWorkflow {
     }
   }
 
+  async restoreUntrackedFiles() {
+    for (const file of this.untrackedFiles ?? []) {
+      await fs.promises.rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
+    }
+  }
+
   /**
    * Restore original HEAD state in case of errors
    */
@@ -338,6 +398,12 @@ export class GitWorkflow {
       // Clean out patch
       await unlink(this.getHiddenFilepath(PATCH_UNSTAGED))
 
+      // TODO
+      // await Promise.all(this.untrackedFiles.map((file) => unlink(this.getHiddenFilepath(file))))
+      for (const file of this.untrackedFiles ?? []) {
+        await fs.promises.rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
+      }
+
       debugLog('Done restoring original state!')
     } catch (error) {
       handleError(error, ctx, RestoreOriginalStateError)
@@ -351,6 +417,10 @@ export class GitWorkflow {
     try {
       debugLog('Dropping backup stash...')
       await this.execGit(['stash', 'drop', '--quiet', await this.getBackupStash(ctx)])
+      // for (const file of this.untrackedFiles ?? []) {
+      //   await fs.promises.rm(this.getHiddenFilepath(file), { recursive: true, force: true })
+      // }
+
       debugLog('Done dropping backup stash!')
     } catch (error) {
       handleError(error, ctx)

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -321,9 +321,16 @@ export class GitWorkflow {
     }
   }
 
-  async hideUntrackedFiles() {
-    for (const file of this.untrackedFiles ?? []) {
-      await rename(path.resolve(this.topLevelDir, file), this.getHiddenFilepath(file))
+  /**
+   * Remove untracked files, to prevent tasks from seeing them
+   */
+  async hideUntrackedFiles(ctx) {
+    try {
+      for (const file of this.untrackedFiles ?? []) {
+        await rename(path.resolve(this.topLevelDir, file), this.getHiddenFilepath(file))
+      }
+    } catch (error) {
+      handleError(error, ctx, HideUnstagedChangesError)
     }
   }
 

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -243,7 +243,7 @@ export class GitWorkflow {
   }
 
   /**
-   * Create a diff of partially staged files and backup stash if enabled.
+   * Create a diff of unstaged changes and backup stash if enabled.
    */
   async prepare(ctx, task) {
     try {
@@ -251,24 +251,27 @@ export class GitWorkflow {
 
       // Get a list of files with both staged and unstaged changes.
       // Unstaged changes to these files should be hidden before the tasks run.
-      const files = [
-        ...((await this.getPartiallyStagedFiles()) ?? []),
-        ...((await this.getUnstagedFiles()) ?? []),
-      ]
-      this.partiallyStagedFiles = files.length ? files : null
+      this.partiallyStagedFiles = await this.getPartiallyStagedFiles()
 
-      if (this.partiallyStagedFiles) {
-        ctx.hasPartiallyStagedFiles = true
-        const unstagedPatch = this.getHiddenFilepath(PATCH_UNSTAGED)
-        const files = processRenames(this.partiallyStagedFiles)
-        await this.execGit(['diff', ...GIT_DIFF_ARGS, '--output', unstagedPatch, '--', ...files])
-      } else {
-        ctx.hasPartiallyStagedFiles = false
-      }
+      // Get a list of files with unstaged changes.
+      // Changes to these files should be hidden before the tasks run.
+      this.unstagedFiles = await this.getUnstagedFiles()
 
       // Get a list of unstaged files.
       // Unstaged files should be moved to a temporary directory before the tasks run.
       this.untrackedFiles = await this.getUntrackedFiles()
+
+      if (this.partiallyStagedFiles || this.unstagedFiles) {
+        const unstagedPatch = this.getHiddenFilepath(PATCH_UNSTAGED)
+        const files = processRenames([
+          ...((ctx.shouldHidePartiallyStaged && this.partiallyStagedFiles) || []),
+          ...((ctx.shouldHideUnstaged && this.unstagedFiles) || []),
+        ])
+        await this.execGit(['diff', ...GIT_DIFF_ARGS, '--output', unstagedPatch, '--', ...files])
+      }
+
+      ctx.hasPartiallyStagedFiles = !!this.partiallyStagedFiles
+      ctx.hasUnstagedFiles = !!this.unstagedFiles
       ctx.hasUntrackedFiles = !!this.untrackedFiles
 
       /**
@@ -306,11 +309,19 @@ export class GitWorkflow {
   }
 
   /**
-   * Remove unstaged changes to all partially staged files, to avoid tasks from seeing them
+   * Remove unstaged changes depending on configuration, to prevent tasks from seeing them
    */
   async hideUnstagedChanges(ctx) {
     try {
-      const files = processRenames(this.partiallyStagedFiles, false)
+      // The `prepare` function has created a patch with some combination of
+      // `partiallyStagedFiles` and `unstagedFiles`, depending on configuration.
+      const files = processRenames(
+        [
+          ...((ctx.shouldHidePartiallyStaged && this.partiallyStagedFiles) || []),
+          ...((ctx.shouldHideUnstaged && this.unstagedFiles) || []),
+        ],
+        false
+      )
       await this.execGit(['checkout', '--force', '--', ...files])
     } catch (error) {
       /**

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -4,7 +4,7 @@ import path from 'node:path'
 import debug from 'debug'
 
 import { execGit } from './execGit.js'
-import { readFile, unlink, writeFile } from './file.js'
+import { readFile, rename, unlink, writeFile } from './file.js'
 import { getDiffCommand } from './getDiffCommand.js'
 import {
   ApplyEmptyCommitError,
@@ -308,7 +308,7 @@ export class GitWorkflow {
 
   async hideUntrackedFiles() {
     for (const file of this.untrackedFiles ?? []) {
-      await fs.promises.rename(path.resolve(this.topLevelDir, file), this.getHiddenFilepath(file))
+      await rename(path.resolve(this.topLevelDir, file), this.getHiddenFilepath(file))
     }
   }
 
@@ -373,7 +373,7 @@ export class GitWorkflow {
 
   async restoreUntrackedFiles() {
     for (const file of this.untrackedFiles ?? []) {
-      await fs.promises.rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
+      await rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
     }
   }
 
@@ -394,7 +394,7 @@ export class GitWorkflow {
 
       // Restore untracked files
       for (const file of this.untrackedFiles ?? []) {
-        await fs.promises.rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
+        await rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
       }
 
       // Clean out patch and recursively remove hidden directory

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -187,8 +187,7 @@ export class GitWorkflow {
       .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
       .filter((line) => {
         const [index, workingTree] = line
-        // TODO: ....
-        return index !== ' ' && workingTree !== ' ' && index !== '?' && workingTree !== '?'
+        return workingTree !== ' ' && index !== '?' && workingTree !== '?'
       })
       .map((line) => line.substr(3)) // Remove first three letters (index, workingTree, and a whitespace)
       .filter(Boolean) // Filter empty string

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -172,13 +172,11 @@ export class GitWorkflow {
   }
 
   /**
-   * TODO: also unstaged
-   * Get a list of all files with both staged and unstaged modifications.
+   * Get a list of all files whose modification status matches a filter.
    * Renames have special treatment, since the single status line includes
    * both the "from" and "to" filenames, where "from" is no longer on disk.
    */
-  async getPartiallyStagedFiles() {
-    debugLog('Getting partially staged files...')
+  async getFiles(filter) {
     const status = await this.execGit(['status', '-z'])
     /**
      * See https://git-scm.com/docs/git-status#_short_format
@@ -189,43 +187,57 @@ export class GitWorkflow {
      * renamed file, the file names are separated by a NUL character
      * (e.g. `to`\0`from`)
      */
-    const partiallyStaged = status
-      // eslint-disable-next-line no-control-regex
-      .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
-      .filter((line) => {
-        const [index, workingTree] = line
-        return workingTree !== ' ' && index !== '?' && workingTree !== '?'
-      })
-      .map((line) => line.substr(3)) // Remove first three letters (index, workingTree, and a whitespace)
-      .filter(Boolean) // Filter empty string
+    return (
+      status
+        // eslint-disable-next-line no-control-regex
+        .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
+        .filter((line) => {
+          const [index, workingTree] = line
+          return filter(index, workingTree)
+        })
+        .map((line) => line.substr(3)) // Remove first three letters (index, workingTree, and a whitespace)
+        .filter(Boolean) // Filter empty string
+    )
+  }
+
+  /**
+   * Get a list of files with both staged and unstaged changes.
+   */
+  async getPartiallyStagedFiles() {
+    debugLog('Getting partially staged files...')
+
+    const partiallyStaged = await this.getFiles((index, workingTree) => {
+      return index !== ' ' && workingTree !== ' ' && index !== '?' && workingTree !== '?'
+    })
+
     debugLog('Found partially staged files:', partiallyStaged)
     return partiallyStaged.length ? partiallyStaged : null
   }
 
   /**
-   * TODO: ...
+   * Get a list of tracked files without staged changes.
+   */
+  async getUnstagedFiles() {
+    debugLog('Getting unstaged files...')
+
+    const unstaged = await this.getFiles((index, workingTree) => {
+      return index === ' ' && workingTree !== ' '
+    })
+
+    debugLog('Found unstaged files:', unstaged)
+    return unstaged.length ? unstaged : null
+  }
+
+  /**
+   * Get a list of untracked files.
    */
   async getUntrackedFiles() {
     debugLog('Getting untracked files...')
-    const status = await this.execGit(['status', '-z'])
-    /**
-     * See https://git-scm.com/docs/git-status#_short_format
-     * Entries returned in machine format are separated by a NUL character.
-     * The first letter of each entry represents current index status,
-     * and second the working tree. Index and working tree status codes are
-     * separated from the file name by a space. If an entry includes a
-     * renamed file, the file names are separated by a NUL character
-     * (e.g. `to`\0`from`)
-     */
-    const untracked = status
-      // eslint-disable-next-line no-control-regex
-      .split(/\x00(?=[ AMDRCU?!]{2} |$)/)
-      .filter((line) => {
-        const [index, workingTree] = line
-        return index === '?' && workingTree === '?'
-      })
-      .map((line) => line.substr(3)) // Remove first three letters (index, workingTree, and a whitespace)
-      .filter(Boolean) // Filter empty string
+
+    const untracked = await this.getFiles((index, workingTree) => {
+      return index === '?' && workingTree === '?'
+    })
+
     debugLog('Found untracked files:', untracked)
     return untracked.length ? untracked : null
   }
@@ -239,7 +251,11 @@ export class GitWorkflow {
 
       // Get a list of files with both staged and unstaged changes.
       // Unstaged changes to these files should be hidden before the tasks run.
-      this.partiallyStagedFiles = await this.getPartiallyStagedFiles()
+      const files = [
+        ...((await this.getPartiallyStagedFiles()) ?? []),
+        ...((await this.getUnstagedFiles()) ?? []),
+      ]
+      this.partiallyStagedFiles = files.length ? files : null
 
       if (this.partiallyStagedFiles) {
         ctx.hasPartiallyStagedFiles = true

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -371,6 +371,9 @@ export class GitWorkflow {
     }
   }
 
+  /**
+   * Restore untracked files to working tree.
+   */
   async restoreUntrackedFiles() {
     for (const file of this.untrackedFiles ?? []) {
       await rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -393,9 +393,7 @@ export class GitWorkflow {
       await Promise.all(this.deletedFiles.map((file) => unlink(file)))
 
       // Restore untracked files
-      for (const file of this.untrackedFiles ?? []) {
-        await rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
-      }
+      await this.restoreUntrackedFiles()
 
       // Clean out patch and recursively remove hidden directory
       await unlink(this.getHiddenDirectory())

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -87,13 +87,21 @@ export class GitWorkflow {
   }
 
   /**
+   * Get absolute path to directory inside .git, and create it if it does not exist
+   */
+  getHiddenDirectory() {
+    const directory = path.resolve(this.gitConfigDir, '.lint-staged')
+    fs.mkdirSync(directory, { recursive: true })
+    return directory
+  }
+
+  /**
    * Get absolute path to file hidden inside .git
    * @param {string} filename
    */
   getHiddenFilepath(filename) {
-    const dir = path.resolve(this.gitConfigDir, '.lint-staged')
-    fs.mkdirSync(dir, { recursive: true })
-    return path.resolve(dir, `./${filename}`)
+    const directory = this.getHiddenDirectory()
+    return path.resolve(directory, `./${filename}`)
   }
 
   /**
@@ -394,14 +402,13 @@ export class GitWorkflow {
       // If stashing resurrected deleted files, clean them out
       await Promise.all(this.deletedFiles.map((file) => unlink(file)))
 
-      // Clean out patch
-      await unlink(this.getHiddenFilepath(PATCH_UNSTAGED))
-
-      // TODO
-      // await Promise.all(this.untrackedFiles.map((file) => unlink(this.getHiddenFilepath(file))))
+      // Restore untracked files
       for (const file of this.untrackedFiles ?? []) {
         await fs.promises.rename(this.getHiddenFilepath(file), path.resolve(this.topLevelDir, file))
       }
+
+      // Clean out patch and recursively remove hidden directory
+      await unlink(this.getHiddenDirectory())
 
       debugLog('Done restoring original state!')
     } catch (error) {
@@ -416,10 +423,6 @@ export class GitWorkflow {
     try {
       debugLog('Dropping backup stash...')
       await this.execGit(['stash', 'drop', '--quiet', await this.getBackupStash(ctx)])
-      // for (const file of this.untrackedFiles ?? []) {
-      //   await fs.promises.rm(this.getHiddenFilepath(file), { recursive: true, force: true })
-      // }
-
       debugLog('Done dropping backup stash!')
     } catch (error) {
       handleError(error, ctx)

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -251,20 +251,10 @@ export class GitWorkflow {
         ctx.hasPartiallyStagedFiles = false
       }
 
+      // Get a list of unstaged files.
+      // Unstaged files should be moved to a temporary directory before the tasks run.
       this.untrackedFiles = await this.getUntrackedFiles()
-
-      if (this.untrackedFiles) {
-        ctx.hasUntrackedFiles = true
-
-        // for (const file of this.untrackedFiles ?? []) {
-        //   await fs.promises.rename(
-        //     path.resolve(this.topLevelDir, file),
-        //     this.getHiddenFilepath(file)
-        //   )
-        // }
-      } else {
-        ctx.hasUntrackedFiles = false
-      }
+      ctx.hasUntrackedFiles = !!this.untrackedFiles
 
       /**
        * If backup stash should be skipped, no need to continue

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,8 @@ const lintStaged = async (
     // Stashing should be disabled by default when the `diff` option is used
     stash = diff === undefined,
     hidePartiallyStaged = stash,
+    hideUnstaged = false,
+    hideUntracked = false,
     verbose = false,
   } = {},
   logger = console
@@ -112,6 +114,8 @@ const lintStaged = async (
     relative,
     stash,
     hidePartiallyStaged,
+    hideUnstaged,
+    hideUntracked,
     verbose,
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,9 @@ const getMaxArgLength = () => {
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
+ * @param {boolean} [options.hidePartiallyStaged] - Hide unstaged changes from partially staged files
+ * @param {boolean} [options.hideUnstaged] - Hide unstaged files
+ * @param {boolean} [options.hideUntracked] - Hide untracked files
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
  * @param {Logger} [logger]
  *

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -51,6 +51,28 @@ export const skippingHidePartiallyStaged = (stash, diff) => {
   )
 }
 
+export const skippingHideUnstaged = (stash, diff) => {
+  const reason =
+    diff !== undefined
+      ? '`--diff` was used'
+      : !stash
+        ? '`--no-stash` was used'
+        : '`--no-hide-unstaged` was used'
+
+  return chalk.yellow(`${warning} Skipping hiding unstaged files because ${reason}.\n`)
+}
+
+export const skippingHideUntracked = (stash, diff) => {
+  const reason =
+    diff !== undefined
+      ? '`--diff` was used'
+      : !stash
+        ? '`--no-stash` was used'
+        : '`--no-hide-untracked` was used'
+
+  return chalk.yellow(`${warning} Skipping hiding untracked files because ${reason}.\n`)
+}
+
 export const DEPRECATED_GIT_ADD = chalk.yellow(
   `${warning} Some of your tasks use \`git add\` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.
 `

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -24,6 +24,8 @@ import {
   SKIPPED_GIT_ERROR,
   skippingBackup,
   skippingHidePartiallyStaged,
+  skippingHideUnstaged,
+  skippingHideUntracked,
 } from './messages.js'
 import { normalizePath } from './normalizePath.js'
 import { resolveGitRepo } from './resolveGitRepo.js'
@@ -83,6 +85,8 @@ export const runAll = async (
     // Stashing should be disabled by default when the `diff` option is used
     stash = diff === undefined,
     hidePartiallyStaged = stash,
+    hideUnstaged = false,
+    hideUntracked = false,
     verbose = false,
   },
   logger = console
@@ -119,6 +123,16 @@ export const runAll = async (
   ctx.shouldHidePartiallyStaged = hidePartiallyStaged
   if (!ctx.shouldHidePartiallyStaged && !quiet) {
     logger.warn(skippingHidePartiallyStaged(hasInitialCommit && stash, diff))
+  }
+
+  ctx.shouldHideUnstaged = hideUnstaged
+  if (!ctx.shouldHideUnstaged && !quiet) {
+    logger.warn(skippingHideUnstaged(hasInitialCommit && stash, diff))
+  }
+
+  ctx.shouldHideUntracked = hideUntracked
+  if (!ctx.shouldHideUntracked && !quiet) {
+    logger.warn(skippingHideUntracked(hasInitialCommit && stash, diff))
   }
 
   const files = await getStagedFiles({ cwd: topLevelDir, diff, diffFilter })

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -36,7 +36,9 @@ import {
   restoreOriginalStateEnabled,
   restoreOriginalStateSkipped,
   restoreUnstagedChangesSkipped,
+  restoreUntrackedFilesSkipped,
   shouldHidePartiallyStagedFiles,
+  shouldHideUntrackedFiles,
 } from './state.js'
 import { ConfigNotFoundError, GetStagedFilesError, GitError, GitRepoError } from './symbols.js'
 
@@ -301,6 +303,11 @@ export const runAll = async (
         enabled: shouldHidePartiallyStagedFiles,
       },
       {
+        title: 'Hiding untracked files...',
+        task: (ctx) => git.hideUntrackedFiles(ctx),
+        enabled: shouldHideUntrackedFiles,
+      },
+      {
         title: `Running tasks for ${diff ? 'changed' : 'staged'} files...`,
         task: (ctx, task) => task.newListr(listrTasks, { concurrent }),
         skip: () => listrTasks.every((task) => task.skip()),
@@ -315,6 +322,12 @@ export const runAll = async (
         task: (ctx) => git.restoreUnstagedChanges(ctx),
         enabled: shouldHidePartiallyStagedFiles,
         skip: restoreUnstagedChangesSkipped,
+      },
+      {
+        title: 'Restoring untracked files...',
+        task: (ctx) => git.restoreUntrackedFiles(ctx),
+        enabled: shouldHideUntrackedFiles,
+        skip: restoreUntrackedFilesSkipped,
       },
       {
         title: 'Reverting to original state because of errors...',

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -38,6 +38,7 @@ import {
   restoreUnstagedChangesSkipped,
   restoreUntrackedFilesSkipped,
   shouldHidePartiallyStagedFiles,
+  shouldHideUnstagedFiles,
   shouldHideUntrackedFiles,
 } from './state.js'
 import { ConfigNotFoundError, GetStagedFilesError, GitError, GitRepoError } from './symbols.js'
@@ -298,9 +299,9 @@ export const runAll = async (
         task: (ctx, task) => git.prepare(ctx, task),
       },
       {
-        title: 'Hiding unstaged changes to partially staged files...',
+        title: 'Hiding unstaged changes...',
         task: (ctx) => git.hideUnstagedChanges(ctx),
-        enabled: shouldHidePartiallyStagedFiles,
+        enabled: (ctx) => shouldHidePartiallyStagedFiles(ctx) || shouldHideUnstagedFiles(ctx),
       },
       {
         title: 'Hiding untracked files...',
@@ -318,9 +319,9 @@ export const runAll = async (
         skip: applyModificationsSkipped,
       },
       {
-        title: 'Restoring unstaged changes to partially staged files...',
+        title: 'Restoring unstaged changes...',
         task: (ctx) => git.restoreUnstagedChanges(ctx),
-        enabled: shouldHidePartiallyStagedFiles,
+        enabled: (ctx) => shouldHidePartiallyStagedFiles(ctx) || shouldHideUnstagedFiles(ctx),
         skip: restoreUnstagedChangesSkipped,
       },
       {

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -65,6 +65,9 @@ const createError = (ctx) => Object.assign(new Error('lint-staged failed'), { ct
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
  * @param {boolean} [options.stash] - Enable the backup stash, and revert in case of errors
+ * @param {boolean} [options.hidePartiallyStaged] - Hide unstaged changes from partially staged files
+ * @param {boolean} [options.hideUnstaged] - Hide unstaged files
+ * @param {boolean} [options.hideUntracked] - Hide untracked files
  * @param {boolean} [options.verbose] - Show task output even when tasks succeed; by default only failed output is shown
  * @param {Logger} logger
  * @returns {Promise}

--- a/lib/state.js
+++ b/lib/state.js
@@ -13,6 +13,7 @@ export const getInitialState = ({ quiet = false } = {}) => ({
   shouldBackup: null,
   backupHash: null,
   shouldHidePartiallyStaged: true,
+  shouldHideUntracked: true,
   errors: new Set([]),
   events: new EventEmitter(),
   output: [],
@@ -21,6 +22,8 @@ export const getInitialState = ({ quiet = false } = {}) => ({
 
 export const shouldHidePartiallyStagedFiles = (ctx) =>
   ctx.hasPartiallyStagedFiles && ctx.shouldHidePartiallyStaged
+
+export const shouldHideUntrackedFiles = (ctx) => ctx.hasUntrackedFiles && ctx.shouldHideUntracked
 
 export const applyModificationsSkipped = (ctx) => {
   // Always apply back unstaged modifications when skipping backup
@@ -36,6 +39,18 @@ export const applyModificationsSkipped = (ctx) => {
 }
 
 export const restoreUnstagedChangesSkipped = (ctx) => {
+  // Should be skipped in case of git errors
+  if (ctx.errors.has(GitError)) {
+    return GIT_ERROR
+  }
+
+  // Should be skipped when tasks fail
+  if (ctx.errors.has(TaskError)) {
+    return TASK_ERROR
+  }
+}
+
+export const restoreUntrackedFilesSkipped = (ctx) => {
   // Should be skipped in case of git errors
   if (ctx.errors.has(GitError)) {
     return GIT_ERROR

--- a/lib/state.js
+++ b/lib/state.js
@@ -10,9 +10,12 @@ import {
 
 export const getInitialState = ({ quiet = false } = {}) => ({
   hasPartiallyStagedFiles: null,
+  hasUnstagedFiles: null,
+  hasUntrackedFiles: null,
   shouldBackup: null,
   backupHash: null,
   shouldHidePartiallyStaged: true,
+  shouldHideUnstaged: true,
   shouldHideUntracked: true,
   errors: new Set([]),
   events: new EventEmitter(),
@@ -22,6 +25,8 @@ export const getInitialState = ({ quiet = false } = {}) => ({
 
 export const shouldHidePartiallyStagedFiles = (ctx) =>
   ctx.hasPartiallyStagedFiles && ctx.shouldHidePartiallyStaged
+
+export const shouldHideUnstagedFiles = (ctx) => ctx.hasUnstagedFiles && ctx.shouldHideUnstaged
 
 export const shouldHideUntrackedFiles = (ctx) => ctx.hasUntrackedFiles && ctx.shouldHideUntracked
 

--- a/test/integration/git-lock-file.test.js
+++ b/test/integration/git-lock-file.test.js
@@ -32,6 +32,8 @@ describe('lint-staged', () => {
 
         const diff = await execGit(['diff'])
 
+        await execGit(['add', 'add-git-lock.mjs'])
+
         // Run lint-staged with `prettier --write` and commit pretty file
         // The task creates a git lock file and runs `git add` to simulate failure
         await expect(

--- a/test/integration/partially-staged-changes.test.js
+++ b/test/integration/partially-staged-changes.test.js
@@ -27,9 +27,9 @@ describe('lint-staged', () => {
 
       const output = await gitCommit()
 
-      expect(output).toMatch('Hiding unstaged changes to partially staged files...')
+      expect(output).toMatch('Hiding unstaged changes...')
       expect(output).toMatch('Applying modifications from tasks...')
-      expect(output).toMatch('Restoring unstaged changes to partially staged files...')
+      expect(output).toMatch('Restoring unstaged changes...')
 
       // Nothing is wrong, so a new commit is created and file is pretty
       expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')

--- a/test/integration/symlink-git-dir.test.js
+++ b/test/integration/symlink-git-dir.test.js
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 import { jest } from '@jest/globals'
 
+import { createTempDir } from '../__utils__/createTempDir.js'
 import { prettierListDifferent } from './__fixtures__/configs.js'
 import { prettyJS } from './__fixtures__/files.js'
 import { withGitIntegration } from './__utils__/withGitIntegration.js'
@@ -14,9 +15,10 @@ describe('lint-staged', () => {
   test(
     'supports symlinked git dir',
     withGitIntegration(async ({ cwd, execGit, gitCommit, readFile, writeFile }) => {
-      // Rename `.git` to `git` and add symbolic link pointing to it
-      await fs.rename(path.resolve(cwd, '.git'), path.resolve(cwd, 'git'))
-      await fs.symlink(path.resolve(cwd, 'git'), path.resolve(cwd, '.git'), 'dir')
+      const tempDir = await createTempDir()
+      // Move `.git` to tempDir and add symbolic link pointing to it
+      await fs.rename(path.resolve(cwd, '.git'), path.resolve(cwd, tempDir))
+      await fs.symlink(path.resolve(cwd, tempDir), path.resolve(cwd, '.git'), 'dir')
 
       await writeFile('.lintstagedrc.json', JSON.stringify(prettierListDifferent))
 


### PR DESCRIPTION
closes #1551, closes #1402, and probably closes #968 

This branch adds `--hide-unstaged` and `--hide-untracked` CLI options.  I'm still adding some tests, but all of the tests were passing before I made these options default to `false`.