### PR TITLE
fix: optimize file list length calculation

### DIFF
--- a/.changeset/real-clowns-smile.md
+++ b/.changeset/real-clowns-smile.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Optimize file list length calculation in chunkFiles to reduce memory usage by avoiding intermediate string concatenation

--- a/lib/chunkFiles.js
+++ b/lib/chunkFiles.js
@@ -52,7 +52,9 @@ export const chunkFiles = ({ files, baseDir, maxArgLength = null, relative = fal
     return [normalizedFiles] // wrap in an array to return a single chunk
   }
 
-  const fileListLength = normalizedFiles.map((file) => file.filepath).join(' ').length
+  const fileListLength = normalizedFiles.reduce((totalLength, file, index) => {
+    return totalLength + file.filepath.length + (index > 0 ? 1 : 0)
+  }, 0)
   debugLog(
     `Resolved an argument string length of ${fileListLength} characters from ${normalizedFiles.length} files`
   )


### PR DESCRIPTION
Replaced string concatenation approach with direct length calculation to reduce memory usage. The current implementation creates an intermediate array of file paths and then joins them into a single large string to calculate the total length. The new approach uses reduce() to calculate the total length in a single pass, eliminating unnecessary allocations.