### PR TITLE
perf: combine `git ls-files` calls into single process

### DIFF
--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -55,16 +55,15 @@ export const searchConfigs = async (
     return { [configPath]: validateConfig(config, filepath, logger) }
   }
 
-  const [cachedFilesWithStatus, otherFilesWithStatus] = await Promise.all([
-    /** Get all possible config files known to git */
-    execGit([...EXEC_GIT, '--', ...CONFIG_PATHSPEC], { cwd }).then(parseGitZOutput),
-    /** Get all possible config files from uncommitted files */
-    execGit([...EXEC_GIT, '--others', '--exclude-standard', '--', ...CONFIG_PATHSPEC], {
-      cwd,
-    }).then(parseGitZOutput),
-  ])
-
-  const gitListedFiles = Array.from(new Set([...cachedFilesWithStatus, ...otherFilesWithStatus]))
+  /** Get all possible config files from git (both cached and uncommitted) */
+  const gitListedFiles = await execGit([
+    ...EXEC_GIT,
+    '--cached',           // includes indexed and committed files
+    '--others',           // includes untracked files
+    '--exclude-standard', // excludes files per .gitignore
+    '--',
+    ...CONFIG_PATHSPEC
+  ], { cwd }).then(parseGitZOutput)
 
   debugLog('Git listed files matching config files:', gitListedFiles)
 

--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -58,9 +58,9 @@ export const searchConfigs = async (
   /** Get all possible config files from git (both cached and uncommitted) */
   const gitListedFiles = await execGit([
     ...EXEC_GIT,
-    '--cached',           // includes indexed and committed files
-    '--others',           // includes untracked files
-    '--exclude-standard', // excludes files per .gitignore
+    '--cached',           // show all tracked files
+    '--others',           // show untracked files
+    '--exclude-standard', // apply standard git exclusions (.gitignore, etc.)
     '--',
     ...CONFIG_PATHSPEC
   ], { cwd }).then(parseGitZOutput)

--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -56,14 +56,17 @@ export const searchConfigs = async (
   }
 
   /** Get all possible config files from git (both cached and uncommitted) */
-  const gitListedFiles = await execGit([
-    ...EXEC_GIT,
-    '--cached',           // show all tracked files
-    '--others',           // show untracked files
-    '--exclude-standard', // apply standard git exclusions (.gitignore, etc.)
-    '--',
-    ...CONFIG_PATHSPEC
-  ], { cwd }).then(parseGitZOutput)
+  const gitListedFiles = await execGit(
+    [
+      ...EXEC_GIT,
+      '--cached', // show all tracked files
+      '--others', // show untracked files
+      '--exclude-standard', // apply standard git exclusions (.gitignore, etc.)
+      '--',
+      ...CONFIG_PATHSPEC,
+    ],
+    { cwd }
+  ).then(parseGitZOutput)
 
   debugLog('Git listed files matching config files:', gitListedFiles)
 


### PR DESCRIPTION
Replace two separate `git ls-files` executions with one combined call using `--cached` and `--others` flags. This reduces process creation overhead, especially on Windows where CreateProcess is expensive.