### PR TITLE
perf: parallelize staged files retrieval and config search

### DIFF
--- a/.changeset/evil-hats-doubt.md
+++ b/.changeset/evil-hats-doubt.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Increase performance by listing staged files and searching for configuration concurrently.

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -130,7 +130,12 @@ export const runAll = async (
     logger.warn(SKIPPING_HIDE_PARTIALLY_CHANGED)
   }
 
-  const stagedFiles = await getStagedFiles({ cwd: topLevelDir, diff, diffFilter })
+  // Run staged files retrieval and config search in parallel since they're independent
+  const [stagedFiles, foundConfigs] = await Promise.all([
+    getStagedFiles({ cwd: topLevelDir, diff, diffFilter }),
+    searchConfigs({ configObject, configPath, cwd, topLevelDir }, logger),
+  ])
+
   if (!stagedFiles) {
     if (!quiet) ctx.output.push(FAILED_GET_STAGED_FILES)
     ctx.errors.add(GetStagedFilesError)
@@ -144,7 +149,6 @@ export const runAll = async (
     return ctx
   }
 
-  const foundConfigs = await searchConfigs({ configObject, configPath, cwd, topLevelDir }, logger)
   const numberOfConfigs = Object.keys(foundConfigs).length
 
   // Throw if no configurations were found


### PR DESCRIPTION
Run `getStagedFiles()` and `searchConfigs()` concurrently. This should eliminate potential sequential I/O