### PR TITLE
perf: combine multiple git add calls into single operation

### DIFF
--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -275,9 +275,12 @@ export class GitWorkflow {
   async applyModifications(ctx) {
     debugLog('Adding task modifications to index...')
 
+    // Collect all addable files from all chunks first
+    const allAddableFiles = []
+
     // `matchedFileChunks` includes staged files that lint-staged originally detected and matched against a task.
     // Add only these files so any 3rd-party edits to other files won't be included in the commit.
-    // These additions per chunk are run "serially" to prevent race conditions.
+    // Files are processed serially to avoid race conditions, then added in a single git command.
     // Git add creates a lockfile in the repo causing concurrent operations to fail.
     for (const files of this.matchedFileChunks) {
       const accessCheckedFiles = await Promise.allSettled(
@@ -295,7 +298,12 @@ export class GitWorkflow {
         r.status === 'fulfilled' ? [r.value] : []
       )
 
-      await this.execGit(['add', '--', ...addableFiles])
+      allAddableFiles.push(...addableFiles)
+    }
+
+    // Add all files in a single git add command instead of multiple calls
+    if (allAddableFiles.length > 0) {
+      await this.execGit(['add', '--', ...allAddableFiles])
     }
 
     debugLog('Done adding task modifications to index!')


### PR DESCRIPTION
Instead of executing git add for each file chunk separately (N ops where N = number of chunks), collect all addable files and execute a single git add command. This reduces git operations and minimizes `.git/index.lock` conflicts while maintaining existing functionality.

## Might be interesting

<details>
  <summary>Script I used for benchmarking</summary>

```js
import { bench, run, summary } from 'mitata';
import { spawn } from 'node:child_process';
import fs from 'node:fs/promises';

const exec = (cmd, args) => new Promise((resolve, reject) => {
  const proc = spawn(cmd, args, { stdio: 'ignore' });
  proc.on('close', code => code === 0 ? resolve() : reject());
});

const createFiles = async (count) => {
  const files = [];
  for (let i = 0; i < count; i++) {
    const name = `file${i}.txt`;
    await fs.writeFile(name, `content ${i}`);
    files.push(name);
  }
  return files;
};

const cleanup = (files) => Promise.all(files.map(f => fs.unlink(f).catch(() => {})));

summary(() => {
  bench('N git add operations', async () => {
    const files = await createFiles(100);
    try {
      await exec('git', ['reset']);
      for (let i = 0; i < files.length; i += 10) {
        const chunk = files.slice(i, i + 10);
        await exec('git', ['add', '--', ...chunk]);
      }
    } finally {
      await cleanup(files);
    }
  });

  bench('single git add operation', async () => {
    const files = await createFiles(100);
    try {
      await exec('git', ['reset']);
      await exec('git', ['add', '--', ...files]);
    } finally {
      await cleanup(files);
    }
  });
});

await run();
```
</details>


<details>
  <summary>Numbers we got</summary>

```
runtime: node 23.5.0 (x64-win32)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
N git add operations         291.78 ms/iter 300.14 ms       █  █          █
                    (267.41 ms … 322.34 ms) 306.10 ms ▅     █  █▅▅    ▅▅  █
                    (901.59 kb …   1.81 mb)   1.63 mb █▁▁▁▁▁█▁▁███▁▁▁▁██▁▁█

single git add operation      82.68 ms/iter  85.15 ms █  █     █
                      (74.65 ms … 93.32 ms)  92.98 ms █  █  ▅▅ █ ▅    ▅   ▅
                    (231.78 kb …   1.20 mb)   1.06 mb █▁▁█▁▁██▁█▁█▁▁▁▁█▁▁▁█
```
</details>