### PR TITLE
fix: add root-level "types" field to package.json

### DIFF
--- a/.changeset/upset-beans-mate.md
+++ b/.changeset/upset-beans-mate.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Add another `types` field to `package.json` to make even more sure NPM detects that _lint-staged_ includes built-in TypeScript type definitions.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "./bin": "./bin/lint-staged.js",
     "./package.json": "./package.json"
   },
+  "types": "./lib/index.d.ts",
   "files": [
     "bin/",
     "lib/",


### PR DESCRIPTION
Follow-up to #1602 