### PR TITLE
fix: kill subprocesses with "SIGKILL" and only if main process has a pid

### DIFF
--- a/.changeset/slick-parrots-add.md
+++ b/.changeset/slick-parrots-add.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Try to improve terminating of subprocess of tasks by using `SIGKILL`, and only calling `pidtree` when the the main task process has a known pid.

--- a/lib/getSpawnedTask.js
+++ b/lib/getSpawnedTask.js
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 import debug from 'debug'
 import spawn from 'nano-spawn'
-import pidTree from 'pidtree'
+import pidtree from 'pidtree'
 import { parseArgsStringToArgv } from 'string-argv'
 
 import { error, info } from './figures.js'
@@ -45,19 +45,20 @@ const handleOutput = (command, result, ctx, isError = false) => {
 const killSubprocess = async (subprocess) => {
   const childProcess = await subprocess.nodeChildProcess
 
-  try {
-    const childPids = await pidTree(childProcess.pid)
-    for (const childPid of childPids) {
-      try {
-        process.kill(childPid)
-      } catch (error) {
-        debugLog(`Failed to kill process with pid "%d": %o`, childPid, error)
+  if (childProcess?.pid !== undefined) {
+    try {
+      for (const childPid of await pidtree(childProcess.pid)) {
+        try {
+          process.kill(childPid, 'SIGKILL')
+        } catch (error) {
+          debugLog(`Failed to kill process with pid "%d": %o`, childPid, error)
+        }
       }
+    } catch (error) {
+      // Suppress "No matching pid found" error. This probably means
+      // the process already died before executing.
+      debugLog(`Failed to list child processes of pid "%d": %o`, childProcess.pid, error)
     }
-  } catch (error) {
-    // Suppress "No matching pid found" error. This probably means
-    // the process already died before executing.
-    debugLog(`Failed to kill process with pid "%d": %o`, childProcess.pid, error)
   }
 
   // The child process is terminated separately in order to get the `KILLED` status.
@@ -85,7 +86,9 @@ const interruptExecutionOnError = (ctx, subprocess) => {
 
   return async () => {
     ctx.events.off(TASK_ERROR, errorListener)
-    await killPromise
+    if (killPromise) {
+      await killPromise
+    }
   }
 }
 


### PR DESCRIPTION
Trying to improve behavior of process-killing related to https://github.com/lint-staged/lint-staged/issues/1559