### PR TITLE
feat: add --exit-code flag

### DIFF
--- a/.changeset/fifty-tires-itch.md
+++ b/.changeset/fifty-tires-itch.md
@@ -1,0 +1,10 @@
+---
+'lint-staged': minor
+---
+
+Added a new option `--exit-code` to make _lint-staged_ exit with code 1 when tasks modify any files, making the `precommit` hook fail. This is in line with the `git diff --exit-code` option. When combined with the `--no-revert` flag, this can be used to make the committer manually stage any task modifications, and attempt to commit again.
+
+```shell
+# Fail when tasks modify files, forcing the committer to stage them manually
+npx lint-staged --no-revert --exit-code
+```

--- a/README.md
+++ b/README.md
@@ -130,27 +130,73 @@ Any lost modifications can be restored from a git stash:
   > git stash apply --index stash@{0}
 ```
 
-- **`--allow-empty`**: By default, when tasks undo all staged changes, lint-staged will exit with an error and abort the commit. Use this flag to allow creating empty git commits.
-- **`--concurrent [number|boolean]`**: Controls the [concurrency of tasks](#task-concurrency) being run by lint-staged. **NOTE**: This does NOT affect the concurrency of subtasks (they will always be run sequentially). Possible values are:
-  - `false`: Run all tasks serially
-  - `true` (default) : _Infinite_ concurrency. Runs as many tasks in parallel as possible.
-  - `{number}`: Run the specified number of tasks in parallel, where `1` is equivalent to `false`.
-- **`--config [path]`**: Manually specify a path to a config file or npm package name. Note: when used, lint-staged won't perform the config file search and will print an error if the specified file cannot be found. If '-' is provided as the filename then the config will be read from stdin, allowing piping in the config like `cat my-config.json | npx lint-staged --config -`.
-- **`--cwd [path]`**: By default tasks run in the current working directory. Use the `--cwd some/directory` to override this. The path can be absolute or relative to the current working directory.
-- **`--debug`**: Run in debug mode. When set, it does the following:
-  - uses [debug](https://github.com/visionmedia/debug) internally to log additional information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
-  - uses [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) for `listr2`; this causes serial, uncoloured output to the terminal, instead of the default (beautified, dynamic) output.
-    (the [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) can also be activated by setting the `TERM=dumb` or `NODE_ENV=test` environment variables)
-- **`--diff`**: By default tasks are filtered against all files staged in git, generated from `git diff --staged`. This option allows you to override the `--staged` flag with arbitrary revisions. For example to get a list of changed files between two branches, use `--diff="branch1...branch2"`. You can also read more from about [git diff](https://git-scm.com/docs/git-diff) and [gitrevisions](https://git-scm.com/docs/gitrevisions). This option also implies `--no-stash`.
-- **`--diff-filter`**: By default only files that are _added_, _copied_, _modified_, or _renamed_ are included. Use this flag to override the default `ACMR` value with something else: _added_ (`A`), _copied_ (`C`), _deleted_ (`D`), _modified_ (`M`), _renamed_ (`R`), _type changed_ (`T`), _unmerged_ (`U`), _unknown_ (`X`), or _pairing broken_ (`B`). See also the `git diff` docs for [--diff-filter](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203).
-- **`--exit-code`**: By default modifications made by tasks are automatically staged and added to the commit. This flag disables the behavior and makes _lint-staged_ exit with code 1, failing the commit instead. When combined with the `--no-revert` flag the committer will have to manually stage all the changes and try again.
-- **`--max-arg-length`**: long commands (a lot of files) are automatically split into multiple chunks when it detects the current shell cannot handle them. Use this flag to override the maximum length of the generated command string.
-- **`--no-stash`**: By default a backup stash will be created before running the tasks, and all task modifications will be reverted in case of an error. This option will disable creating the stash, and instead leave all modifications in the index when aborting the commit.
-- **`--no-hide-partially-staged`**: By default, unstaged changes from partially staged files will be hidden and applied back after running tasks. This option will disable this behavior, causing those changes to also be committed.
-- **`--quiet`**: Suppress all CLI output, except from tasks.
-- **`--relative`**: Pass filepaths relative to `process.cwd()` (where `lint-staged` runs) to tasks. Default is `false`.
-- **`--no-revert`**: By default all task modifications will be reverted in case of an error. This option will disable the behavior, and apply task modifications to the index before aborting the commit.
-- **`--verbose`**: Show task output even when tasks succeed. By default only failed output is shown.
+#### `--allow-empty`
+
+By default, when tasks undo all staged changes, lint-staged will exit with an error and abort the commit. Use this flag to allow creating empty git commits.
+
+#### `--concurrent [number|boolean]`
+
+Controls the [concurrency of tasks](#task-concurrency) being run by lint-staged. **NOTE**: This does NOT affect the concurrency of subtasks (they will always be run sequentially). Possible values are:
+
+- `false`: Run all tasks serially
+- `true` (default) : _Infinite_ concurrency. Runs as many tasks in parallel as possible.
+- `{number}`: Run the specified number of tasks in parallel, where `1` is equivalent to `false`.
+
+#### `--config [path]`
+
+Manually specify a path to a config file or npm package name. Note: when used, lint-staged won't perform the config file search and will print an error if the specified file cannot be found. If '-' is provided as the filename then the config will be read from stdin, allowing piping in the config like `cat my-config.json | npx lint-staged --config -`.
+
+#### `--cwd [path]`
+
+By default tasks run in the current working directory. Use the `--cwd some/directory` to override this. The path can be absolute or relative to the current working directory.
+
+#### `--debug`
+
+Run in debug mode. When set, it does the following:
+
+- uses [debug](https://github.com/visionmedia/debug) internally to log additional information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
+- uses [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) for `listr2`; this causes serial, uncoloured output to the terminal, instead of the default (beautified, dynamic) output.
+  (the [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) can also be activated by setting the `TERM=dumb` or `NODE_ENV=test` environment variables)
+
+#### `--diff`
+
+By default tasks are filtered against all files staged in git, generated from `git diff --staged`. This option allows you to override the `--staged` flag with arbitrary revisions. For example to get a list of changed files between two branches, use `--diff="branch1...branch2"`. You can also read more from about [git diff](https://git-scm.com/docs/git-diff) and [gitrevisions](https://git-scm.com/docs/gitrevisions). This option also implies `--no-stash`.
+
+#### `--diff-filter [string]`
+
+By default only files that are _added_, _copied_, _modified_, or _renamed_ are included. Use this flag to override the default `ACMR` value with something else: _added_ (`A`), _copied_ (`C`), _deleted_ (`D`), _modified_ (`M`), _renamed_ (`R`), _type changed_ (`T`), _unmerged_ (`U`), _unknown_ (`X`), or _pairing broken_ (`B`). See also the `git diff` docs for [--diff-filter](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203).
+
+#### `--exit-code`
+
+By default modifications made by tasks are automatically staged and added to the commit. This flag disables the behavior and makes _lint-staged_ exit with code 1, failing the commit instead. When combined with the `--no-revert` flag the committer will have to manually stage all the changes and try again.
+
+#### `--max-arg-length [number]`
+
+long commands (a lot of files) are automatically split into multiple chunks when it detects the current shell cannot handle them. Use this flag to override the maximum length of the generated command string.
+
+#### `--no-stash`
+
+By default a backup stash will be created before running the tasks, and all task modifications will be reverted in case of an error. This option will disable creating the stash, and instead leave all modifications in the index when aborting the commit.
+
+#### `--no-hide-partially-staged`
+
+By default, unstaged changes from partially staged files will be hidden and applied back after running tasks. This option will disable this behavior, causing those changes to also be committed.
+
+#### `--quiet`
+
+Suppress all CLI output, except from tasks.
+
+#### `--relative`
+
+Pass filepaths relative to `process.cwd()` (where `lint-staged` runs) to tasks. Default is `false`.
+
+#### `--no-revert`
+
+By default all task modifications will be reverted in case of an error. This option will disable the behavior, and apply task modifications to the index before aborting the commit.
+
+#### `--verbose`
+
+Show task output even when tasks succeed. By default only failed output is shown.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -112,14 +112,15 @@ Options:
   --diff [string]                    override the default "--staged" flag of "git diff" to get list of files. Implies
                                      "--no-stash".
   --diff-filter [string]             override the default "--diff-filter=ACMR" flag of "git diff" to get list of files
+  --exit-code                        fail with exit code 1 when tasks modify tracked files (default: false)
   --max-arg-length [number]          maximum length of the command-line argument string (default: 0)
   --no-revert                        do not revert to original state in case of errors.
   --no-stash                         disable the backup stash. Implies "--no-revert".
   --no-hide-partially-staged         disable hiding unstaged changes from partially staged files
   -q, --quiet                        disable lint-staged’s own console output (default: false)
   -r, --relative                     pass relative filepaths to tasks (default: false)
-  -v, --verbose                      show task output even when tasks succeed; by default only failed output is
-                                     shown (default: false)
+  -v, --verbose                      show task output even when tasks succeed; by default only failed output is shown
+                                     (default: false)
   -h, --help                         display help for command
 
 Any lost modifications can be restored from a git stash:
@@ -142,6 +143,7 @@ Any lost modifications can be restored from a git stash:
     (the [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) can also be activated by setting the `TERM=dumb` or `NODE_ENV=test` environment variables)
 - **`--diff`**: By default tasks are filtered against all files staged in git, generated from `git diff --staged`. This option allows you to override the `--staged` flag with arbitrary revisions. For example to get a list of changed files between two branches, use `--diff="branch1...branch2"`. You can also read more from about [git diff](https://git-scm.com/docs/git-diff) and [gitrevisions](https://git-scm.com/docs/gitrevisions). This option also implies `--no-stash`.
 - **`--diff-filter`**: By default only files that are _added_, _copied_, _modified_, or _renamed_ are included. Use this flag to override the default `ACMR` value with something else: _added_ (`A`), _copied_ (`C`), _deleted_ (`D`), _modified_ (`M`), _renamed_ (`R`), _type changed_ (`T`), _unmerged_ (`U`), _unknown_ (`X`), or _pairing broken_ (`B`). See also the `git diff` docs for [--diff-filter](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---diff-filterACDMRTUXB82308203).
+- **`--exit-code`**: By default modifications made by tasks are automatically staged and added to the commit. This flag disables the behavior and makes _lint-staged_ exit with code 1, failing the commit instead. When combined with the `--no-revert` flag the committer will have to manually stage all the changes and try again.
 - **`--max-arg-length`**: long commands (a lot of files) are automatically split into multiple chunks when it detects the current shell cannot handle them. Use this flag to override the maximum length of the generated command string.
 - **`--no-stash`**: By default a backup stash will be created before running the tasks, and all task modifications will be reverted in case of an error. This option will disable creating the stash, and instead leave all modifications in the index when aborting the commit.
 - **`--no-hide-partially-staged`**: By default, unstaged changes from partially staged files will be hidden and applied back after running tasks. This option will disable this behavior, causing those changes to also be committed.

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -58,6 +58,8 @@ program.option(
   'override the default "--diff-filter=ACMR" flag of "git diff" to get list of files'
 )
 
+program.option('--exit-code', 'fail with exit code 1 when tasks modify tracked files', false)
+
 program.option('--max-arg-length [number]', 'maximum length of the command-line argument string', 0)
 
 /**
@@ -120,6 +122,7 @@ const options = {
   debug: !!cliOptions.debug,
   diff: cliOptions.diff,
   diffFilter: cliOptions.diffFilter,
+  exitCode: !!cliOptions.exitCode,
   maxArgLength: cliOptions.maxArgLength || undefined,
   quiet: !!cliOptions.quiet,
   relative: !!cliOptions.relative,

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -21,53 +21,65 @@ const debugLog = debug('lint-staged:bin')
 // Do not terminate main Listr process on SIGINT
 process.on('SIGINT', () => {})
 
-program.version(await getVersion())
-
-/**
- * This shouldn't be necessary for lint-staged, but add migration step just in case
- * to preserve old behavior of "commander".
- *
- * @todo remove this in the major version
- * @see https://github.com/tj/commander.js/releases/tag/v13.0.0
- * */
-program.allowExcessArguments()
-
-program.option('--allow-empty', 'allow empty commits when tasks revert all staged changes', false)
-
-program.option(
-  '-p, --concurrent <number|boolean>',
-  'the number of tasks to run concurrently, or false for serial',
-  true
-)
-
-program.option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
-
-program.option('--cwd [path]', 'run all tasks in specific directory, instead of the current')
-
-program.option('-d, --debug', 'print additional debug information', false)
-
-program.addOption(
-  new Option(
-    '--diff [string]',
-    'override the default "--staged" flag of "git diff" to get list of files. Implies "--no-stash".'
-  ).implies({ stash: false })
-)
-
-program.option(
-  '--diff-filter [string]',
-  'override the default "--diff-filter=ACMR" flag of "git diff" to get list of files'
-)
-
-program.option('--exit-code', 'fail with exit code 1 when tasks modify tracked files', false)
-
-program.option('--max-arg-length [number]', 'maximum length of the command-line argument string', 0)
-
-/**
- * We don't want to show the `--revert` flag because it's on by default, and only show the
- * negatable flag `--no-rever` instead. There seems to be a bug in Commander.js where
- * configuring only the latter won't actually set the default value.
- */
 program
+  .version(await getVersion())
+
+  /**
+   * This shouldn't be necessary for lint-staged, but add migration step just in case
+   * to preserve old behavior of "commander".
+   *
+   * @todo remove this in the major version
+   * @see https://github.com/tj/commander.js/releases/tag/v13.0.0
+   * */
+  .allowExcessArguments()
+
+  .addOption(
+    new Option('--allow-empty', 'allow empty commits when tasks revert all staged changes').default(
+      false
+    )
+  )
+  .addOption(
+    new Option(
+      '-p, --concurrent <number|boolean>',
+      'the number of tasks to run concurrently, or false for serial'
+    ).default(true)
+  )
+  .addOption(
+    new Option('-c, --config [path]', 'path to configuration file, or - to read from stdin')
+  )
+  .addOption(
+    new Option('--cwd [path]', 'run all tasks in specific directory, instead of the current')
+  )
+  .addOption(new Option('-d, --debug', 'print additional debug information').default(false))
+  .addOption(
+    new Option(
+      '--diff [string]',
+      'override the default "--staged" flag of "git diff" to get list of files. Implies "--no-stash".'
+    ).implies({ stash: false })
+  )
+  .addOption(
+    new Option(
+      '--diff-filter [string]',
+      'override the default "--diff-filter=ACMR" flag of "git diff" to get list of files'
+    )
+  )
+  .addOption(
+    new Option('--exit-code', 'fail with exit code 1 when tasks modify tracked files').default(
+      false
+    )
+  )
+  .addOption(
+    new Option(
+      '--max-arg-length [number]',
+      'maximum length of the command-line argument string'
+    ).default(0)
+  )
+
+  /**
+   * We don't want to show the `--revert` flag because it's on by default, and only show the
+   * negatable flag `--no-rever` instead. There seems to be a bug in Commander.js where
+   * configuring only the latter won't actually set the default value.
+   */
   .addOption(
     new Option('--revert', 'revert to original state in case of errors').default(true).hideHelp()
   )
@@ -75,7 +87,6 @@ program
     new Option('--no-revert', 'do not revert to original state in case of errors.').default(false)
   )
 
-program
   .addOption(new Option('--stash', 'enable the backup stash').default(true).hideHelp())
   .addOption(
     new Option('--no-stash', 'disable the backup stash. Implies "--no-revert".')
@@ -83,7 +94,6 @@ program
       .implies({ revert: false })
   )
 
-program
   .addOption(
     new Option('--hide-partially-staged', 'hide unstaged changes from partially staged files')
       .default(true)
@@ -96,17 +106,16 @@ program
     ).default(false)
   )
 
-program.option('-q, --quiet', 'disable lint-staged’s own console output', false)
+  .addOption(new Option('-q, --quiet', 'disable lint-staged’s own console output').default(false))
+  .addOption(new Option('-r, --relative', 'pass relative filepaths to tasks').default(false))
+  .addOption(
+    new Option(
+      '-v, --verbose',
+      'show task output even when tasks succeed; by default only failed output is shown'
+    ).default(false)
+  )
 
-program.option('-r, --relative', 'pass relative filepaths to tasks', false)
-
-program.option(
-  '-v, --verbose',
-  'show task output even when tasks succeed; by default only failed output is shown',
-  false
-)
-
-program.addHelpText('afterAll', '\n' + RESTORE_STASH_EXAMPLE)
+  .addHelpText('afterAll', '\n' + RESTORE_STASH_EXAMPLE)
 
 const cliOptions = program.parse(process.argv).opts()
 

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
@@ -8,6 +9,7 @@ import { readFile, unlink, writeFile } from './file.js'
 import { getDiffCommand } from './getDiffCommand.js'
 import {
   ApplyEmptyCommitError,
+  ExitCodeError,
   GetBackupStashError,
   GitError,
   HideUnstagedChangesError,
@@ -66,21 +68,32 @@ const handleError = (error, ctx, symbol) => {
   throw error
 }
 
+const calculateSha256 = (input) => crypto.createHash('sha256').update(input, 'utf-8').digest('hex')
+
 export class GitWorkflow {
   /**
    * @param {Object} opts
    * @param {import('./getStagedFiles.js').StagedFile[][]} opts.matchedFileChunks
    */
-  constructor({ allowEmpty, gitConfigDir, topLevelDir, matchedFileChunks, diff, diffFilter }) {
+  constructor({
+    allowEmpty,
+    diff,
+    diffFilter,
+    exitCode,
+    gitConfigDir,
+    matchedFileChunks,
+    topLevelDir,
+  }) {
     this.execGit = (args, options = {}) => execGit(args, { ...options, cwd: topLevelDir })
+    this.allowEmpty = allowEmpty
     this.deletedFiles = []
-    this.gitConfigDir = gitConfigDir
-    this.topLevelDir = topLevelDir
     this.diff = diff
     this.diffFilter = diffFilter
-    this.allowEmpty = allowEmpty
+    this.gitConfigDir = gitConfigDir
+    this.exitCode = !!exitCode
     /** @type {import('./getStagedFiles.js').StagedFile[][]} */
     this.matchedFileChunks = matchedFileChunks
+    this.topLevelDir = topLevelDir
 
     /**
      * These three files hold state about an ongoing git merge
@@ -204,6 +217,11 @@ export class GitWorkflow {
     try {
       debugLog(task.title)
 
+      if (this.exitCode) {
+        const diff = await this.execGit(['diff', '--patch', '--unified=0'])
+        this.unstagedDiffSha256 = calculateSha256(diff)
+      }
+
       // Get a list of files with both staged and unstaged changes.
       // Unstaged changes to these files should be hidden before the tasks run.
       this.partiallyStagedFiles = await this.getPartiallyStagedFiles()
@@ -273,6 +291,15 @@ export class GitWorkflow {
    * In case of a merge-conflict retry with 3-way merge.
    */
   async applyModifications(ctx) {
+    if (this.exitCode) {
+      const diff = await this.execGit(['diff', '--patch', '--unified=0'])
+      const diffSha256 = calculateSha256(diff)
+      if (this.unstagedDiffSha256 !== diffSha256) {
+        ctx.errors.add(ExitCodeError)
+        throw new Error('Tasks modified files and --exit-code was used!')
+      }
+    }
+
     debugLog('Adding task modifications to index...')
 
     // `matchedFileChunks` includes staged files that lint-staged originally detected and matched against a task.

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -53,6 +53,11 @@ export type Options = {
    */
   diffFilter?: string
   /**
+   * Fail with exit code 1 when tasks modify tracked files
+   * @default false
+   */
+  exitCode?: true
+  /**
    * Maximum argument string length, by default automatically detected
    */
   maxArgLength?: number

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ import {
   GIT_ERROR,
   NO_CONFIGURATION,
   PREVENTED_EMPTY_COMMIT,
+  PREVENTED_TASK_MODIFICATIONS,
   RESTORE_STASH_EXAMPLE,
   UNSTAGED_CHANGES_BACKUP_STASH_LOCATION,
 } from './messages.js'
@@ -14,6 +15,7 @@ import { cleanupSkipped } from './state.js'
 import {
   ApplyEmptyCommitError,
   ConfigNotFoundError,
+  ExitCodeError,
   GetBackupStashError,
   GitError,
   RestoreUnstagedChangesError,
@@ -56,6 +58,7 @@ const getMaxArgLength = () => {
  * @param {boolean} [options.debug] - Enable debug mode
  * @param {string} [options.diff] - Override the default "--staged" flag of "git diff" to get list of files
  * @param {string} [options.diffFilter] - Override the default "--diff-filter=ACMR" flag of "git diff" to get list of files
+ * @param {boolean} [options.exitCode] - Fail with exit code 1 when tasks modify tracked files
  * @param {number} [options.maxArgLength] - Maximum argument string length
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
@@ -76,6 +79,7 @@ const lintStaged = async (
     debug = false,
     diff,
     diffFilter,
+    exitCode = false,
     maxArgLength = getMaxArgLength() / 2,
     quiet = false,
     relative = false,
@@ -112,6 +116,7 @@ const lintStaged = async (
     debug,
     diff,
     diffFilter,
+    exitCode,
     maxArgLength,
     quiet,
     relative,
@@ -140,6 +145,8 @@ const lintStaged = async (
         logger.error(NO_CONFIGURATION)
       } else if (ctx.errors.has(ApplyEmptyCommitError)) {
         logger.warn(PREVENTED_EMPTY_COMMIT)
+      } else if (ctx.errors.has(ExitCodeError)) {
+        logger.warn(PREVENTED_TASK_MODIFICATIONS)
       } else if (ctx.errors.has(RestoreUnstagedChangesError)) {
         logger.warn(UNSTAGED_CHANGES_BACKUP_STASH_LOCATION)
         logger.warn(ctx.unstagedPatch)

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -48,6 +48,8 @@ export const DEPRECATED_GIT_ADD = chalk.yellow(
 
 export const TASK_ERROR = 'Skipped because of errors from tasks.'
 
+export const PREVENTED_TASK_MODIFICATIONS = `\n${error} lint-staged failed because \`--exit-code\` was used.`
+
 export const SKIPPED_GIT_ERROR = 'Skipped because of previous git error.'
 
 export const GIT_ERROR = `\n  ${chalk.redBright(`${error} lint-staged failed due to a git error.`)}`

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -61,6 +61,7 @@ const createError = (ctx, cause) =>
  * @param {boolean} [options.debug] - Enable debug mode
  * @param {string} [options.diff] - Override the default "--staged" flag of "git diff" to get list of files
  * @param {string} [options.diffFilter] - Override the default "--diff-filter=ACMR" flag of "git diff" to get list of files
+ * @param {boolean} [options.exitCode] - Fail with exit code 1 when tasks modify tracked files
  * @param {number} [options.maxArgLength] - Maximum argument string length
  * @param {boolean} [options.quiet] - Disable lint-staged’s own console output
  * @param {boolean} [options.relative] - Pass relative filepaths to tasks
@@ -80,6 +81,7 @@ export const runAll = async (
     debug = false,
     diff,
     diffFilter,
+    exitCode = false,
     maxArgLength,
     quiet = false,
     relative = false,
@@ -295,11 +297,12 @@ export const runAll = async (
 
   const git = new GitWorkflow({
     allowEmpty,
-    gitConfigDir,
-    topLevelDir,
-    matchedFileChunks,
     diff,
     diffFilter,
+    exitCode,
+    gitConfigDir,
+    matchedFileChunks,
+    topLevelDir,
   })
 
   const runner = new Listr(

--- a/lib/state.js
+++ b/lib/state.js
@@ -2,6 +2,7 @@ import EventEmitter from 'events'
 
 import { GIT_ERROR, TASK_ERROR } from './messages.js'
 import {
+  ExitCodeError,
   GitError,
   RestoreOriginalStateError,
   RestoreUnstagedChangesError,
@@ -52,11 +53,17 @@ export const restoreUnstagedChangesSkipped = (ctx) => {
 export const restoreOriginalStateEnabled = (ctx) =>
   !!ctx.shouldRevert &&
   !!ctx.shouldBackup &&
-  (ctx.errors.has(TaskError) || ctx.errors.has(RestoreUnstagedChangesError))
+  (ctx.errors.has(ExitCodeError) ||
+    ctx.errors.has(TaskError) ||
+    ctx.errors.has(RestoreUnstagedChangesError))
 
 export const restoreOriginalStateSkipped = (ctx) => {
   // Should be skipped in case of unknown git errors
-  if (ctx.errors.has(GitError) && !ctx.errors.has(RestoreUnstagedChangesError)) {
+  if (
+    ctx.errors.has(GitError) &&
+    !ctx.errors.has(RestoreUnstagedChangesError) &&
+    !ctx.errors.has(ExitCodeError)
+  ) {
     return GIT_ERROR
   }
 }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -25,3 +25,5 @@ export const RestoreOriginalStateError = Symbol('RestoreOriginalStateError')
 export const RestoreUnstagedChangesError = Symbol('RestoreUnstagedChangesError')
 
 export const TaskError = Symbol('TaskError')
+
+export const ExitCodeError = Symbol('ExitCodeError')

--- a/test/integration/exit-code.test.js
+++ b/test/integration/exit-code.test.js
@@ -1,0 +1,81 @@
+import { jest } from '@jest/globals'
+
+import * as configFixtures from './__fixtures__/configs.js'
+import * as fileFixtures from './__fixtures__/files.js'
+import { withGitIntegration } from './__utils__/withGitIntegration.js'
+
+jest.setTimeout(20000)
+jest.retryTimes(2)
+
+describe('lint-staged', () => {
+  test(
+    'should fail when tasks modify files and --exit-code is used',
+    withGitIntegration(async ({ execGit, gitCommit, readFile, writeFile }) => {
+      await writeFile('.lintstagedrc.json', JSON.stringify(configFixtures.prettierWrite))
+
+      // Stage ugly files
+      await writeFile('test.js', fileFixtures.uglyJS)
+      await execGit(['add', 'test.js'])
+
+      // Run lint-staged with `prettier --write` so that it modifies files
+      await expect(() =>
+        gitCommit({
+          lintStaged: {
+            exitCode: true,
+            quiet: true,
+          },
+        })
+      ).rejects.toThrow('lint-staged failed because `--exit-code` was used')
+
+      expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+      expect(await readFile('test.js')).toEqual(fileFixtures.uglyJS)
+    })
+  )
+
+  test(
+    'should not fail --exit-code is used but tasks do not modify files',
+    withGitIntegration(async ({ execGit, gitCommit, readFile, writeFile }) => {
+      await writeFile('.lintstagedrc.json', JSON.stringify(configFixtures.prettierWrite))
+
+      // Stage ugly files
+      await writeFile('test.js', fileFixtures.prettyJS)
+      await execGit(['add', 'test.js'])
+
+      // Run lint-staged with `prettier --write` so that it modifies files
+      await gitCommit({
+        lintStaged: {
+          exitCode: true,
+          quiet: true,
+        },
+      })
+
+      expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('2')
+      expect(await readFile('test.js')).toEqual(fileFixtures.prettyJS)
+    })
+  )
+
+  test(
+    'should fail and leave task modifications in worktree when --exit-code and --no-revert are used',
+    withGitIntegration(async ({ execGit, gitCommit, readFile, writeFile }) => {
+      await writeFile('.lintstagedrc.json', JSON.stringify(configFixtures.prettierWrite))
+
+      // Stage ugly files
+      await writeFile('test.js', fileFixtures.uglyJS)
+      await execGit(['add', 'test.js'])
+
+      // Run lint-staged with `prettier --write` so that it modifies files
+      await expect(() =>
+        gitCommit({
+          lintStaged: {
+            exitCode: true,
+            revert: false, // --no-revert
+            quiet: true,
+          },
+        })
+      ).rejects.toThrow('lint-staged failed because `--exit-code` was used')
+
+      expect(await execGit(['rev-list', '--count', 'HEAD'])).toEqual('1')
+      expect(await readFile('test.js')).toEqual(fileFixtures.prettyJS)
+    })
+  )
+})


### PR DESCRIPTION
In line with `git diff --exit-code`, make _lint-staged_ exit with code 1 (and prevent commit) when tasks modify any files. This is achieved by calculating SHA-256 hash of `git diff --patch --unified=0` before and after running tasks, before running `git add` on them.

The result is _lint-staged_ will fail the commit if tasks change any files. When combined with `--no-revert`, it forces the developer to manually add changes and try to commit again. Fixes https://github.com/lint-staged/lint-staged/issues/977 and https://github.com/lint-staged/lint-staged/issues/1599