### PR TITLE
feat: remove `debug` as a dependency

### DIFF
--- a/.changeset/dependabot-2838997856.md
+++ b/.changeset/dependabot-2838997856.md
@@ -1,5 +1,0 @@
----
-lint-staged: patch
----
-
-Bumps [debug](https://github.com/debug-js/debug) from 4.4.1 to 4.4.3.

--- a/.changeset/smart-mugs-tap.md
+++ b/.changeset/smart-mugs-tap.md
@@ -1,0 +1,5 @@
+---
+'lint-staged': patch
+---
+
+Remove [debug](https://github.com/debug-js/debug) as a dependency due to recent malware issue; read more at https://github.com/debug-js/debug/issues/1005. Because of this, the `DEBUG` environment variable is no longer supported — use the `--debug` to enable debugging

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ By default tasks run in the current working directory. Use the `--cwd some/direc
 
 Run in debug mode. When set, it does the following:
 
-- uses [debug](https://github.com/visionmedia/debug) internally to log additional information about staged files, commands being executed, location of binaries, etc. Debug logs, which are automatically enabled by passing the flag, can also be enabled by setting the environment variable `$DEBUG` to `lint-staged*`.
+- log additional information about staged files, commands being executed, location of binaries, etc.
 - uses [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) for `listr2`; this causes serial, uncoloured output to the terminal, instead of the default (beautified, dynamic) output.
   (the [`verbose` renderer](https://listr2.kilic.dev/renderers/verbose-renderer/) can also be activated by setting the `TERM=dumb` or `NODE_ENV=test` environment variables)
 

--- a/bin/lint-staged.js
+++ b/bin/lint-staged.js
@@ -3,14 +3,14 @@
 import { userInfo } from 'node:os'
 
 import { Option, program } from 'commander'
-import debug from 'debug'
 
+import { createDebug, enableDebug } from '../lib/debug.js'
 import lintStaged from '../lib/index.js'
 import { CONFIG_STDIN_ERROR, RESTORE_STASH_EXAMPLE } from '../lib/messages.js'
 import { readStdin } from '../lib/readStdin.js'
 import { getVersion } from '../lib/version.js'
 
-const debugLog = debug('lint-staged:bin')
+const debugLog = createDebug('lint-staged:bin')
 
 // Do not terminate main Listr process on SIGINT
 process.on('SIGINT', () => {})
@@ -126,7 +126,7 @@ program
 const cliOptions = program.parse(process.argv).opts()
 
 if (cliOptions.debug) {
-  debug.enable('lint-staged*')
+  enableDebug()
 }
 
 const options = {

--- a/lib/chunkFiles.js
+++ b/lib/chunkFiles.js
@@ -1,10 +1,9 @@
 import path from 'node:path'
 
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { normalizePath } from './normalizePath.js'
 
-const debugLog = debug('lint-staged:chunkFiles')
+const debugLog = createDebug('lint-staged:chunkFiles')
 
 /**
  * Chunk array into sub-arrays

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,27 @@
+import { formatWithOptions } from 'node:util'
+
+import { blackBright, SUPPORTS_COLOR } from './colors.js'
+
+const format = (...args) => formatWithOptions({ colors: SUPPORTS_COLOR }, ...args)
+
+let activeLogger
+
+export const enableDebug = (logger = console) => {
+  if (!activeLogger) {
+    activeLogger = logger
+  }
+}
+
+/** @param {string} name */
+export const createDebug = (name) => {
+  let previous = process.hrtime.bigint()
+
+  return (...args) => {
+    if (!activeLogger) return
+
+    const now = process.hrtime.bigint()
+    const ms = (now - previous) / 1_000_000n
+    previous = now
+    activeLogger.debug(blackBright(name + ': ') + format(...args) + blackBright(` +${ms}ms`))
+  }
+}

--- a/lib/execGit.js
+++ b/lib/execGit.js
@@ -1,7 +1,8 @@
-import debug from 'debug'
 import spawn, { SubprocessError } from 'nano-spawn'
 
-const debugLog = debug('lint-staged:execGit')
+import { createDebug } from './debug.js'
+
+const debugLog = createDebug('lint-staged:execGit')
 
 /**
  * Explicitly never recurse commands into submodules, overriding local/global configuration.

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,8 +1,8 @@
 import fs from 'node:fs/promises'
 
-import debug from 'debug'
+import { createDebug } from './debug.js'
 
-const debugLog = debug('lint-staged:file')
+const debugLog = createDebug('lint-staged:file')
 
 /**
  * Read contents of a file to buffer

--- a/lib/generateTasks.js
+++ b/lib/generateTasks.js
@@ -1,11 +1,11 @@
 import path from 'node:path'
 
-import debug from 'debug'
 import micromatch from 'micromatch'
 
+import { createDebug } from './debug.js'
 import { normalizePath } from './normalizePath.js'
 
-const debugLog = debug('lint-staged:generateTasks')
+const debugLog = createDebug('lint-staged:generateTasks')
 
 /**
  * Generates all task commands, and filelist

--- a/lib/getFunctionTask.js
+++ b/lib/getFunctionTask.js
@@ -1,8 +1,7 @@
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { makeErr } from './getSpawnedTask.js'
 
-const debugLog = debug('lint-staged:getFunctionTasks')
+const debugLog = createDebug('lint-staged:getFunctionTasks')
 
 /**
  * @typedef {{ title: string; task: Function }} FunctionTask

--- a/lib/getSpawnedTask.js
+++ b/lib/getSpawnedTask.js
@@ -1,16 +1,16 @@
-import debug from 'debug'
 import spawn from 'nano-spawn'
 import pidtree from 'pidtree'
 import { parseArgsStringToArgv } from 'string-argv'
 
 import { blackBright, red } from './colors.js'
+import { createDebug } from './debug.js'
 import { error, info } from './figures.js'
 import { getInitialState } from './state.js'
 import { TaskError } from './symbols.js'
 
 const TASK_ERROR = 'lint-staged:taskError'
 
-const debugLog = debug('lint-staged:getSpawnedTask')
+const debugLog = createDebug('lint-staged:getSpawnedTask')
 
 /** @type {(error: import('nano-spawn').SubprocessError) => string} */
 const getTag = (error) => {

--- a/lib/getSpawnedTasks.js
+++ b/lib/getSpawnedTasks.js
@@ -1,9 +1,8 @@
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { getSpawnedTask } from './getSpawnedTask.js'
 import { configurationError } from './messages.js'
 
-const debugLog = debug('lint-staged:getSpawnedTasks')
+const debugLog = createDebug('lint-staged:getSpawnedTasks')
 
 /**
  * Creates and returns an array of listr tasks which map to the given commands.

--- a/lib/gitWorkflow.js
+++ b/lib/gitWorkflow.js
@@ -2,8 +2,7 @@ import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { execGit } from './execGit.js'
 import { readFile, unlink, writeFile } from './file.js'
 import { getDiffCommand } from './getDiffCommand.js'
@@ -18,7 +17,7 @@ import {
   RestoreUnstagedChangesError,
 } from './symbols.js'
 
-const debugLog = debug('lint-staged:GitWorkflow')
+const debugLog = createDebug('lint-staged:GitWorkflow')
 
 const MERGE_HEAD = 'MERGE_HEAD'
 const MERGE_MODE = 'MERGE_MODE'

--- a/lib/groupFilesByConfig.js
+++ b/lib/groupFilesByConfig.js
@@ -1,8 +1,8 @@
 import path from 'node:path'
 
-import debug from 'debug'
+import { createDebug } from './debug.js'
 
-const debugLog = debug('lint-staged:groupFilesByConfig')
+const debugLog = createDebug('lint-staged:groupFilesByConfig')
 
 /**
  * @typedef {import('./getStagedFiles.js').StagedFile} StagedFile

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
-import debugLib from 'debug'
-
 import { SUPPORTS_COLOR } from './colors.js'
+import { createDebug, enableDebug } from './debug.js'
 import { execGit } from './execGit.js'
 import {
   GIT_ERROR,
@@ -24,7 +23,7 @@ import {
 import { validateOptions } from './validateOptions.js'
 import { getVersion } from './version.js'
 
-const debugLog = debugLib('lint-staged')
+const debugLog = createDebug('lint-staged')
 
 /**
  * Get the maximum length of a command-line argument string based on current platform
@@ -102,7 +101,7 @@ const lintStaged = async (
 ) => {
   // Seemingly enable debug twice (also done in bin), so that it also works when using the Node.js API
   if (debug) {
-    debugLib.enable('lint-staged*')
+    enableDebug(logger)
 
     debugLog(
       'Running `lint-staged@%s` on Node.js %s (%s)',

--- a/lib/loadConfig.js
+++ b/lib/loadConfig.js
@@ -3,7 +3,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import debug from 'debug'
 import YAML from 'yaml'
 
 import {
@@ -12,11 +11,12 @@ import {
   PACKAGE_JSON_FILE,
   PACKAGE_YAML_FILES,
 } from './configFiles.js'
+import { createDebug } from './debug.js'
 import { dynamicImport } from './dynamicImport.js'
 import { failedToLoadConfig } from './messages.js'
 import { resolveConfig } from './resolveConfig.js'
 
-const debugLog = debug('lint-staged:loadConfig')
+const debugLog = createDebug('lint-staged:loadConfig')
 
 const jsonParse = (filePath, content) => {
   const isPackageFile = PACKAGE_JSON_FILE.includes(path.basename(filePath))

--- a/lib/resolveGitRepo.js
+++ b/lib/resolveGitRepo.js
@@ -1,11 +1,10 @@
 import path from 'node:path'
 
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { execGit } from './execGit.js'
 import { normalizePath } from './normalizePath.js'
 
-const debugLog = debug('lint-staged:resolveGitRepo')
+const debugLog = createDebug('lint-staged:resolveGitRepo')
 
 /**
  * Relative path up to the repo top-level directory

--- a/lib/runAll.js
+++ b/lib/runAll.js
@@ -2,11 +2,11 @@
 
 import path from 'node:path'
 
-import debug from 'debug'
 import { Listr } from 'listr2'
 
 import { chunkFiles } from './chunkFiles.js'
 import { blackBright } from './colors.js'
+import { createDebug } from './debug.js'
 import { execGit } from './execGit.js'
 import { generateTasks } from './generateTasks.js'
 import { getFunctionTask, isFunctionTask } from './getFunctionTask.js'
@@ -40,7 +40,7 @@ import {
 } from './state.js'
 import { ConfigNotFoundError, GetStagedFilesError, GitError, GitRepoError } from './symbols.js'
 
-const debugLog = debug('lint-staged:runAll')
+const debugLog = createDebug('lint-staged:runAll')
 
 /**
  * @param {ReturnType<typeof getInitialState>} ctx context

--- a/lib/searchConfigs.js
+++ b/lib/searchConfigs.js
@@ -2,16 +2,15 @@
 
 import path from 'node:path'
 
-import debug from 'debug'
-
 import { CONFIG_FILE_NAMES } from './configFiles.js'
+import { createDebug } from './debug.js'
 import { execGit } from './execGit.js'
 import { loadConfig } from './loadConfig.js'
 import { normalizePath } from './normalizePath.js'
 import { parseGitZOutput } from './parseGitZOutput.js'
 import { validateConfig } from './validateConfig.js'
 
-const debugLog = debug('lint-staged:searchConfigs')
+const debugLog = createDebug('lint-staged:searchConfigs')
 
 const EXEC_GIT = ['ls-files', '-z', '--full-name', '-t']
 

--- a/lib/validateConfig.js
+++ b/lib/validateConfig.js
@@ -2,13 +2,12 @@
 
 import { inspect } from 'node:util'
 
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { configurationError, failedToParseConfig } from './messages.js'
 import { ConfigEmptyError, ConfigFormatError } from './symbols.js'
 import { validateBraces } from './validateBraces.js'
 
-const debugLog = debug('lint-staged:validateConfig')
+const debugLog = createDebug('lint-staged:validateConfig')
 
 export const validateConfigLogic = (config, configPath, logger) => {
   debugLog('Validating config from `%s`...', configPath)

--- a/lib/validateOptions.js
+++ b/lib/validateOptions.js
@@ -2,12 +2,11 @@ import { constants } from 'node:fs'
 import fs from 'node:fs/promises'
 import path from 'node:path'
 
-import debug from 'debug'
-
+import { createDebug } from './debug.js'
 import { invalidOption } from './messages.js'
 import { InvalidOptionsError } from './symbols.js'
 
-const debugLog = debug('lint-staged:validateOptions')
+const debugLog = createDebug('lint-staged:validateOptions')
 
 /**
  * Validate lint-staged options, either from the Node.js API or the command line flags.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "commander": "14.0.1",
-        "debug": "4.4.3",
         "lilconfig": "3.1.3",
         "listr2": "9.0.4",
         "micromatch": "4.0.8",
@@ -3061,6 +3060,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4909,6 +4909,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nano-spawn": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "commander": "14.0.1",
-    "debug": "4.4.3",
     "lilconfig": "3.1.3",
     "listr2": "9.0.4",
     "micromatch": "4.0.8",

--- a/test/unit/debug.spec.js
+++ b/test/unit/debug.spec.js
@@ -1,0 +1,26 @@
+import makeConsoleMock from 'consolemock'
+import { describe, expect, it, suite, vi } from 'vitest'
+
+suite('debug', async () => {
+  const logger = makeConsoleMock()
+
+  const { createDebug, enableDebug } = await vi.importActual('../../lib/debug.js')
+
+  describe('enableDebug', () => {
+    it('should enable debugging', ({ expect }) => {
+      expect(enableDebug(logger)).toBe(undefined)
+      expect(enableDebug(logger)).toBe(undefined)
+
+      expect(logger.printHistory()).toBe('')
+    })
+  })
+
+  describe('createDebug', () => {
+    it('should create debug logger', () => {
+      const debug = createDebug('vitest')
+      debug('Testing 1… 2… 3…')
+
+      expect(logger.printHistory()).toMatch('DEBUG vitest: Testing 1… 2… 3…')
+    })
+  })
+})

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -1,16 +1,13 @@
 import makeConsoleMock from 'consolemock'
 import { beforeEach, describe, it, vi } from 'vitest'
 
-vi.mock('debug', () => {
-  const debug = vi.fn().mockReturnValue(vi.fn())
-  debug.enable = vi.fn()
-
-  return { default: debug }
-})
-
-vi.mock('lilconfig', () => ({
-  lilconfig: vi.fn(),
+vi.mock('../../lib/debug.js', () => ({
+  createDebug: vi.fn().mockReturnValue(vi.fn()),
+  enableDebug: vi.fn(),
+  isDebugEnv: vi.fn(),
 }))
+
+vi.mock('lilconfig', () => ({ lilconfig: vi.fn() }))
 
 vi.mock('../../lib/getStagedFiles.js', () => ({ getStagedFiles: vi.fn() }))
 
@@ -20,7 +17,7 @@ vi.mock('../../lib/validateOptions.js', () => ({
   validateOptions: vi.fn().mockImplementation(async () => void {}),
 }))
 
-const { default: debugLib } = await import('debug')
+const { enableDebug } = await import('../../lib/debug.js')
 const { lilconfig } = await import('lilconfig')
 const { getStagedFiles } = await import('../../lib/getStagedFiles.js')
 const { default: lintStaged } = await import('../../lib/index.js')
@@ -48,7 +45,7 @@ describe('lintStaged', () => {
       ERROR ✖ Failed to get staged files!"
     `)
 
-    expect(debugLib.enable).not.toHaveBeenCalled()
+    expect(enableDebug).not.toHaveBeenCalled()
   })
 
   it('should return true when passed', async ({ expect }) => {
@@ -87,6 +84,6 @@ describe('lintStaged', () => {
 
     await lintStaged({ debug: true }, logger)
 
-    expect(debugLib.enable).toHaveBeenCalled()
+    expect(enableDebug).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Remove [debug](https://github.com/debug-js/debug) as a dependency due to recent malware issue; read more at https://github.com/debug-js/debug/issues/1005.