### PR TITLE
fix: change `defineConfig` signature from `const` to a `function`

### DIFF
--- a/.changeset/silly-places-worry.md
+++ b/.changeset/silly-places-worry.md
@@ -1,0 +1,7 @@
+---
+'lint-staged': patch
+---
+
+Fix TypeScript issue `TS1254` from `defineConfig()` by changing the signature from `const` to a `function`:
+
+> A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.

--- a/lib/config.d.ts
+++ b/lib/config.d.ts
@@ -66,4 +66,4 @@ export type Configuration =
  *   "*.js": ["prettier --check", "eslint"]
  * })
  */
-export const defineConfig = (config: Configuration) => config
+export function defineConfig(config: Configuration): Configuration

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,1 +1,14 @@
-export const defineConfig = (configuration) => configuration
+/**
+ * TypeScript helper to define `lint-staged` configuration.
+ * Use as the default export in a configuration file like `lint-staged.config.js`.
+ *
+ * @param {import('./config.d.ts').Configuration} configuration
+ *
+ * @example
+ * export default defineConfig({
+ *   "*.js": ["prettier --check", "eslint"]
+ * })
+ */
+export function defineConfig(configuration) {
+  return configuration
+}


### PR DESCRIPTION
Fix TypeScript issue `TS1254` from `defineConfig()` by changing the signature from `const` to a `function`:

> A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.